### PR TITLE
Move polling frequency to config options

### DIFF
--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -22,6 +22,8 @@ from .const import (
     CONF_READ_METER3
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.config_entries import ConfigEntry
 
 
 def host_valid(host):
@@ -45,6 +47,11 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry):
+        return SolaredgeModbusMultiOptionsFlowHandler(config_entry)
 
     def _host_in_configuration_exists(self, host) -> bool:
         """Return True if host exists in configuration."""
@@ -76,10 +83,6 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors[CONF_NUMBER_INVERTERS] = "min_inverters"
             elif user_input[CONF_NUMBER_INVERTERS] + user_input[CONF_DEVICE_ID] > 247:
                 errors[CONF_NUMBER_INVERTERS] = "too_many_inverters"
-            elif user_input[CONF_SCAN_INTERVAL] < 10:
-                errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
-            elif user_input[CONF_SCAN_INTERVAL] > 86400:
-                errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
             else:
                 await self.async_set_unique_id(user_input[CONF_HOST])
                 self._abort_if_unique_id_configured()
@@ -96,7 +99,6 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_READ_METER1: DEFAULT_READ_METER1,
                 CONF_READ_METER2: DEFAULT_READ_METER2,
                 CONF_READ_METER3: DEFAULT_READ_METER3,
-                CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
             }
 
         return self.async_show_form(
@@ -127,10 +129,50 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(
                         CONF_READ_METER3, default=user_input[CONF_READ_METER3]
                     ): cv.boolean,
+                },
+            ),
+            errors = errors
+        )
+
+class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
+    def __init__(self, config_entry: ConfigEntry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input = None) -> FlowResult:
+        errors = {}
+
+        """Manage the options."""
+        if user_input is not None:
+            
+            if user_input[CONF_SCAN_INTERVAL] < 10:
+                errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
+            elif user_input[CONF_SCAN_INTERVAL] > 86400:
+                errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
+            else:
+                return self.async_create_entry(
+                    title = "",
+                    data = user_input
+                )
+        else:
+            if self.config_entry.options.get(CONF_SCAN_INTERVAL) is None:
+                user_input = {
+                    CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+                }
+            
+            else:
+                user_input = {
+                    CONF_SCAN_INTERVAL: self.config_entry.options.get(CONF_SCAN_INTERVAL),
+                }
+
+        return self.async_show_form(
+            step_id = "init",
+            data_schema = vol.Schema(
+                {
                     vol.Optional(
                         CONF_SCAN_INTERVAL, default=user_input[CONF_SCAN_INTERVAL]
                     ): vol.Coerce(int),
                 },
             ),
-            errors=errors
+            errors = errors
         )

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -11,8 +11,7 @@
           "number_of_inverters": "Number of Inverters",
           "read_meter_1": "Use Meter 1",
           "read_meter_2": "Use Meter 2",
-          "read_meter_3": "Use Meter 3",
-          "scan_interval": "Polling Frequency (seconds)"
+          "read_meter_3": "Use Meter 3"
         }
       }
     },
@@ -22,13 +21,25 @@
       "min_device_id": "Device ID must be between 1 to 247.",
       "max_inverters": "Must be between 1 to 32 inverters.",
       "min_inverters": "Must be between 1 to 32 inverters.",
-      "too_many_inverters": "Number of inverters too high for Device ID",
+      "too_many_inverters": "Number of inverters too high for Device ID.",
       "invalid_host": "Invalid IP address.",
-      "invalid_tcp_port": "Valid port range is 1 to 65535.",
-      "invalid_scan_interval": "Valid interval is 10 to 86400 seconds."
+      "invalid_tcp_port": "Valid port range is 1 to 65535."
     },
     "abort": {
       "already_configured": "Device is already configured!"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "SolarEdge Modbus Options",
+        "data": {
+          "scan_interval": "Polling Frequency (seconds)"
+        }
+      }
+    },
+    "error": {
+      "invalid_scan_interval": "Valid interval is 10 to 86400 seconds."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -11,8 +11,7 @@
           "number_of_inverters": "Anzahl Wechselrichter",
           "read_meter_1": "Verwenden Sie Meter 1",
           "read_meter_2": "Verwenden Sie Meter 2",
-          "read_meter_3": "Verwenden Sie Meter 3",
-          "scan_interval": "Abfragehäufigkeit (Sekunden)"
+          "read_meter_3": "Verwenden Sie Meter 3"
         }
       }
     },
@@ -24,11 +23,23 @@
       "min_inverters": "Muss zwischen 1 und 32 Wechselrichtern liegen.",
       "too_many_inverters": "Anzahl Wechselrichter zu hoch für Geräte-ID.",
       "invalid_host": "Ungültige IP-Adresse.",
-      "invalid_tcp_port": "Der gültige Portbereich ist 1 bis 65535.",
-      "invalid_scan_interval": "Gültiges Intervall ist 10 bis 86400 Sekunden."
+      "invalid_tcp_port": "Der gültige Portbereich ist 1 bis 65535."
     },
     "abort": {
       "already_configured": "Der Wechselrichter ist bereits konfiguriert."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "SolarEdge Modbus Options",
+        "data": {
+          "scan_interval": "Abfragehäufigkeit (Sekunden)"
+        }
+      }
+    },
+    "error": {
+      "invalid_scan_interval": "Gültiges Intervall ist 10 bis 86400 Sekunden."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -11,8 +11,7 @@
           "number_of_inverters": "Number of Inverters",
           "read_meter_1": "Use Meter 1",
           "read_meter_2": "Use Meter 2",
-          "read_meter_3": "Use Meter 3",
-          "scan_interval": "Polling Frequency (seconds)"
+          "read_meter_3": "Use Meter 3"
         }
       }
     },
@@ -24,11 +23,23 @@
       "min_inverters": "Must be between 1 to 32 inverters.",
       "too_many_inverters": "Number of inverters too high for Device ID.",
       "invalid_host": "Invalid IP address.",
-      "invalid_tcp_port": "Valid port range is 1 to 65535.",
-      "invalid_scan_interval": "Valid interval is 10 to 86400 seconds."
+      "invalid_tcp_port": "Valid port range is 1 to 65535."
     },
     "abort": {
       "already_configured": "Device is already configured!"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "SolarEdge Modbus Options",
+        "data": {
+          "scan_interval": "Polling Frequency (seconds)"
+        }
+      }
+    },
+    "error": {
+      "invalid_scan_interval": "Valid interval is 10 to 86400 seconds."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -11,8 +11,7 @@
           "device_id": "Inverter Modbus-adresse (enhets-ID)",
           "read_meter_1": "Bruk måler 1",
           "read_meter_2": "Bruk måler 2",
-          "read_meter_3": "Bruk måler 3",
-          "scan_interval": "Avstemningsfrekvens (sekunder)"
+          "read_meter_3": "Bruk måler 3"
         }
       }
     },
@@ -24,11 +23,23 @@
       "min_inverters": "Må være mellom 1 og 32 omformere.",
       "too_many_inverters": "Antall invertere for høyt for enhets-ID.",
       "invalid_host": "Ugyldig IP-adresse.",
-      "invalid_tcp_port": "Gyldig portområde er 1 til 65535.",
-      "invalid_scan_interval": "Gyldig intervall er 10 til 86400 sekunder."
+      "invalid_tcp_port": "Gyldig portområde er 1 til 65535."
     },
     "abort": {
       "already_configured": "Enheten er allerede konfigurert"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "SolarEdge Modbus Options",
+        "data": {
+          "scan_interval": "Avstemningsfrekvens (sekunder)"
+        }
+      }
+    },
+    "error": {
+      "invalid_scan_interval": "Gyldig intervall er 10 til 86400 sekunder."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -11,8 +11,7 @@
           "device_id": "Omvormer Modbus-adres (apparaat-ID)",
           "read_meter_1": "Gebruik meter 1",
           "read_meter_2": "Gebruik meter 2",
-          "read_meter_3": "Gebruik meter 3",
-          "scan_interval": "Oproepfrequentie (seconden)"
+          "read_meter_3": "Gebruik meter 3"
         }
       }
     },
@@ -24,11 +23,23 @@
       "min_inverters": "Moet tussen 1 en 32 omvormers zijn.",
       "too_many_inverters": "Aantal omvormers te hoog voor Device ID.",
       "invalid_host": "Ongeldig IP-adres.",
-      "invalid_tcp_port": "Geldig poortbereik is 1 tot 65535.",
-      "invalid_scan_interval": "Geldig interval is 10 tot 86400 seconden."
+      "invalid_tcp_port": "Geldig poortbereik is 1 tot 65535."
     },
     "abort": {
       "already_configured": "Apparaat is al geconfigureerd"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "SolarEdge Modbus Options",
+        "data": {
+          "scan_interval": "Oproepfrequentie (seconden)"
+        }
+      }
+    },
+    "error": {
+      "invalid_scan_interval": "Geldig interval is 10 tot 86400 seconden."
     }
   }
 }


### PR DESCRIPTION
Move configuration for polling frequency out of the setup config and into the options config so it can be changed at any time. Existing config value will be imported into options.