### PR TITLE
New config option: keep connection open

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is designed to communicate locally using Modbus/TCP where you have a single L
 * Meter support for 1 to 3 meters per inverter.
 * Battery support for 1 or 2 batteries per inverter.
 * Automatically detects meters and batteries.
-* Polling frequency configuration option (10 to 86400 seconds).
+* Polling frequency configuration option (1 to 86400 seconds).
 * Configurable starting inverter device ID.
 * Connects using Modbus/TCP - no cloud dependencies.
 * Informational sensor for device and its attributes

--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -16,7 +16,7 @@ from .const import (
     CONF_DEVICE_ID,
     CONF_DETECT_METERS, DEFAULT_DETECT_METERS,
     CONF_DETECT_BATTERIES, DEFAULT_DETECT_BATTERIES,
-    CONF_SINGLE_DEVICE_ENTITY, DEFAULT_SINGLE_DEVICE_ENTITY,
+    CONF_SINGLE_DEVICE_ENTITY, DEFAULT_SINGLE_DEVICE_ENTITY, CONF_KEEP_MODBUS_OPEN,
 )
 
 PLATFORMS: list[str] = ["sensor"]
@@ -46,6 +46,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.options.get(CONF_DETECT_METERS, DEFAULT_DETECT_METERS),
         entry.options.get(CONF_DETECT_BATTERIES, DEFAULT_DETECT_BATTERIES),
         entry.options.get(CONF_SINGLE_DEVICE_ENTITY, DEFAULT_SINGLE_DEVICE_ENTITY),
+        entry.options.get(CONF_KEEP_MODBUS_OPEN, CONF_KEEP_MODBUS_OPEN),
     )
     
     await solaredge_hub.async_init_solaredge()

--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -16,7 +16,8 @@ from .const import (
     CONF_DEVICE_ID,
     CONF_DETECT_METERS, DEFAULT_DETECT_METERS,
     CONF_DETECT_BATTERIES, DEFAULT_DETECT_BATTERIES,
-    CONF_SINGLE_DEVICE_ENTITY, DEFAULT_SINGLE_DEVICE_ENTITY, CONF_KEEP_MODBUS_OPEN,
+    CONF_SINGLE_DEVICE_ENTITY, DEFAULT_SINGLE_DEVICE_ENTITY,
+    CONF_KEEP_MODBUS_OPEN, DEFAULT_KEEP_MODBUS_OPEN,
 )
 
 PLATFORMS: list[str] = ["sensor"]
@@ -46,7 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.options.get(CONF_DETECT_METERS, DEFAULT_DETECT_METERS),
         entry.options.get(CONF_DETECT_BATTERIES, DEFAULT_DETECT_BATTERIES),
         entry.options.get(CONF_SINGLE_DEVICE_ENTITY, DEFAULT_SINGLE_DEVICE_ENTITY),
-        entry.options.get(CONF_KEEP_MODBUS_OPEN, CONF_KEEP_MODBUS_OPEN),
+        entry.options.get(CONF_KEEP_MODBUS_OPEN, DEFAULT_KEEP_MODBUS_OPEN),
     )
     
     await solaredge_hub.async_init_solaredge()

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -15,11 +15,13 @@ from .const import (
     DEFAULT_DETECT_METERS,
     DEFAULT_DETECT_BATTERIES,
     DEFAULT_SINGLE_DEVICE_ENTITY,
+    DEFAULT_KEEP_MODBUS_OPEN,
     CONF_DEVICE_ID,
     CONF_NUMBER_INVERTERS,
     CONF_DETECT_METERS,
     CONF_DETECT_BATTERIES,
     CONF_SINGLE_DEVICE_ENTITY,
+    CONF_KEEP_MODBUS_OPEN,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
@@ -133,7 +135,7 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
         """Manage the options."""
         if user_input is not None:
             
-            if user_input[CONF_SCAN_INTERVAL] < 10:
+            if user_input[CONF_SCAN_INTERVAL] < 1:
                 errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
             elif user_input[CONF_SCAN_INTERVAL] > 86400:
                 errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
@@ -146,6 +148,7 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
             user_input = {
                 CONF_SCAN_INTERVAL: self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
                 CONF_SINGLE_DEVICE_ENTITY: self.config_entry.options.get(CONF_SINGLE_DEVICE_ENTITY, DEFAULT_SINGLE_DEVICE_ENTITY),
+                CONF_KEEP_MODBUS_OPEN: self.config_entry.options.get(CONF_KEEP_MODBUS_OPEN, DEFAULT_KEEP_MODBUS_OPEN),
                 CONF_DETECT_METERS: self.config_entry.options.get(CONF_DETECT_METERS, DEFAULT_DETECT_METERS),
                 CONF_DETECT_BATTERIES: self.config_entry.options.get(CONF_DETECT_BATTERIES, DEFAULT_DETECT_BATTERIES),
             }
@@ -159,6 +162,9 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
                     ): vol.Coerce(int),
                     vol.Optional(
                         CONF_SINGLE_DEVICE_ENTITY, default=user_input[CONF_SINGLE_DEVICE_ENTITY]
+                    ): cv.boolean,
+                    vol.Optional(
+                        CONF_KEEP_MODBUS_OPEN, default=user_input[CONF_KEEP_MODBUS_OPEN]
                     ): cv.boolean,
                     vol.Optional(
                         CONF_DETECT_METERS, default=user_input[CONF_DETECT_METERS]

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -7,11 +7,13 @@ DEFAULT_DEVICE_ID = 1
 DEFAULT_DETECT_METERS = True
 DEFAULT_DETECT_BATTERIES = False
 DEFAULT_SINGLE_DEVICE_ENTITY = True
+DEFAULT_KEEP_MODBUS_OPEN = False
 CONF_NUMBER_INVERTERS = "number_of_inverters"
 CONF_DEVICE_ID = "device_id"
 CONF_DETECT_METERS = "detect_meters"
 CONF_DETECT_BATTERIES = "detect_batteries"
 CONF_SINGLE_DEVICE_ENTITY = "single_device_entity"
+CONF_KEEP_MODBUS_OPEN = "keep_modbus_open"
 
 # units missing in homeassistant core
 ENERGY_VOLT_AMPERE_HOUR = "VAh"

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -61,8 +61,8 @@ class SolarEdgeModbusMultiHub:
         self.data = {}
 
         if (
-            not self._keep_modbus_open and
-            self._polling_interval < 10
+            scan_interval < 10 and
+            not self._keep_modbus_open
         ):
             _LOGGER.warning("Polling frequency < 10, enabling keep modbus open option.")
             self._keep_modbus_open = True

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -41,6 +41,7 @@ class SolarEdgeModbusMultiHub:
         detect_meters: bool = True,
         detect_batteries: bool = False,
         single_device_entity: bool = True,
+        keep_modbus_open: bool = False,
     ):
         """Initialize the Modbus hub."""
         self._hass = hass
@@ -55,8 +56,16 @@ class SolarEdgeModbusMultiHub:
         self._detect_meters = detect_meters
         self._detect_batteries = detect_batteries
         self._single_device_entity = single_device_entity
+        self._keep_modbus_open = keep_modbus_open
         self._sensors = []
         self.data = {}
+
+        if (
+            not self._keep_modbus_open and
+            self._polling_interval < 10
+        ):
+            _LOGGER.warning("Polling frequency < 10, enabling keep modbus open option.")
+            self._keep_modbus_open = True
 
         self._client = ModbusTcpClient(host=self._host, port=self._port)
         
@@ -151,7 +160,8 @@ class SolarEdgeModbusMultiHub:
         except:
             raise ConfigEntryNotReady(f"Devices not ready.")
 
-        self.close()
+        if not self._keep_modbus_open:
+            self.close()
 
         self._polling_interval = async_track_time_interval(
             self._hass, self.async_refresh_modbus_data, self._scan_interval
@@ -197,7 +207,8 @@ class SolarEdgeModbusMultiHub:
                 for battery in self.batteries:
                     await battery.publish_updates()
 
-        self.close()
+        if not self._keep_modbus_open:
+            self.close()
 
     @property
     def name(self):

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -43,7 +43,7 @@
       }
     },
     "error": {
-      "invalid_scan_interval": "Valid interval is 10 to 86400 seconds."
+      "invalid_scan_interval": "Valid interval is 1 to 86400 seconds."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -36,6 +36,7 @@
         "data": {
           "scan_interval": "Polling Frequency (seconds)",
           "single_device_entity": "Single Device Entity",
+          "keep_modbus_open": "Keep Modbus Connection Open",
           "detect_meters": "Auto-Detect Meters",
           "detect_batteries": "Auto-Detect Batteries"
         }

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -36,13 +36,14 @@
         "data": {
           "scan_interval": "Abfragehäufigkeit (Sekunden)",
           "single_device_entity": "Einzelne Geräteeinheit",
+          "keep_modbus_open": "Modbus-Verbindung geöffnet lassen",
           "detect_meters": "Messgeräte automatisch erkennen",
           "detect_batteries": "Batterien automatisch erkennen"
         }
       }
     },
     "error": {
-      "invalid_scan_interval": "Gültiges Intervall ist 10 bis 86400 Sekunden."
+      "invalid_scan_interval": "Gültiges Intervall ist 1 bis 86400 Sekunden."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -36,13 +36,14 @@
         "data": {
           "scan_interval": "Polling Frequency (seconds)",
           "single_device_entity": "Single Device Entity",
+          "keep_modbus_open": "Keep Modbus Connection Open",
           "detect_meters": "Auto-Detect Meters",
           "detect_batteries": "Auto-Detect Batteries"
        }
       }
     },
     "error": {
-      "invalid_scan_interval": "Valid interval is 10 to 86400 seconds."
+      "invalid_scan_interval": "Valid interval is 1 to 86400 seconds."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -36,13 +36,14 @@
         "data": {
           "scan_interval": "Avstemningsfrekvens (sekunder)",
           "single_device_entity": "Enkelt enhetsenhet",
+          "keep_modbus_open": "Hold Modbus-tilkoblingen åpen",
           "detect_meters": "Automatisk oppdagelse av målere",
           "detect_batteries": "Automatisk gjenkjenning av batterier"
         }
       }
     },
     "error": {
-      "invalid_scan_interval": "Gyldig intervall er 10 til 86400 sekunder."
+      "invalid_scan_interval": "Gyldig intervall er 1 til 86400 sekunder."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -36,13 +36,14 @@
         "data": {
           "scan_interval": "Oproepfrequentie (seconden)",
           "single_device_entity": "Entiteit met één apparaat",
+          "keep_modbus_open": "Houd Modbus-verbinding open",
           "detect_meters": "Meters automatisch detecteren",
           "detect_batteries": "Batterijen automatisch detecteren"
         }
       }
     },
     "error": {
-      "invalid_scan_interval": "Geldig interval is 10 tot 86400 seconden."
+      "invalid_scan_interval": "Geldig interval is 1 tot 86400 seconden."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -36,13 +36,14 @@
         "data": {
           "scan_interval": "Częstotliwość odczytu (sekundy)",
           "single_device_entity": "Użyj jednej encji dla urządzenia",
+          "keep_modbus_open": "Pozostaw połączenie Modbus otwarte",
           "detect_meters": "Automatycznie wykryj liczniki",
           "detect_batteries": "Automatycznie wykryj baterie"
         }
       }
     },
     "error": {
-      "invalid_scan_interval": "Próbkowanie musi być w zakresie od 10 do 86400 sekund."
+      "invalid_scan_interval": "Próbkowanie musi być w zakresie od 1 do 86400 sekund."
     }
   }
 }

--- a/info.md
+++ b/info.md
@@ -25,7 +25,7 @@ Make sure you have a full backup before making changes - backups are always best
 * Meter support for 1 to 3 meters per inverter.
 * Battery support for 1 or 2 batteries per inverter.
 * Automatically detects meters and batteries.
-* Polling frequency configuration option (10 to 86400 seconds).
+* Polling frequency configuration option (1 to 86400 seconds).
 * Configurable starting inverter device ID.
 * Connects using Modbus/TCP - no cloud dependencies.
 * Informational sensor for device and its attributes


### PR DESCRIPTION
* Adds new option "Keep Modbus Connection Open". When enabled, the integration won't close the connection after each polling cycle. Default is disabled.
* Allows poling intervals down to 1 second. For any interval under 10 seconds, it will force "Keep Modbus Connection Open" to be enabled even if disabled in options (a warning will be logged).