### PR TITLE
Duplicate meters after initial setup

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -91,7 +91,7 @@ class SolarEdgeModbusMultiHub:
         self.inverters = []
         self.meters = []
         self.batteries = []
-        self.inverter_common = []
+        self.inverter_common = {}
         self.initalized = False
         self.online = False
 
@@ -683,7 +683,10 @@ class SolarEdgeMeter:
         self.serial = self.decoded_common["C_SerialNumber"]
         self.device_address = self.decoded_common["C_Device_address"]
         self.name = f"{self.hub.hub_id.capitalize()} M{self.meter_id}"
-        self.uid_base = f"{self.model}_{self.serial}"
+
+        inverter_model = self.inverter_common["C_Model"]
+        inerter_serial = self.inverter_common["C_SerialNumber"]
+        self.uid_base = f"{inverter_model}_{inerter_serial}_M{self.meter_id}"
 
         self._device_info = {
             "identifiers": {(DOMAIN, f"{self.model}_{self.serial}")},

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -683,7 +683,6 @@ class SolarEdgeMeter:
         self.serial = self.decoded_common["C_SerialNumber"]
         self.device_address = self.decoded_common["C_Device_address"]
         self.name = f"{self.hub.hub_id.capitalize()} M{self.meter_id}"
-        self.uid_base = f"{self.model}_{self.serial}"
 
         inverter_model = self.inverter_common["C_Model"]
         inerter_serial = self.inverter_common["C_SerialNumber"]
@@ -953,7 +952,10 @@ class SolarEdgeBattery:
         self.serial = self.decoded_common["B_SerialNumber"]
         self.device_address = self.decoded_common["B_Device_Address"]
         self.name = f"{self.hub.hub_id.capitalize()} B{self.battery_id}"
-        self.uid_base = f"{self.model}_{self.serial}"
+
+        inverter_model = self.inverter_common["C_Model"]
+        inerter_serial = self.inverter_common["C_SerialNumber"]
+        self.uid_base = f"{inverter_model}_{inerter_serial}_B{self.battery_id}"
 
         self._device_info = {
             "identifiers": {(DOMAIN, f"{self.model}_{self.serial}")},

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -91,6 +91,7 @@ class SolarEdgeModbusMultiHub:
         self.inverters = []
         self.meters = []
         self.batteries = []
+        self.inverter_common = []
         self.initalized = False
         self.online = False
 
@@ -443,6 +444,8 @@ class SolarEdgeInverter:
                 ),
             )
 
+        self.hub.inverter_common[self.inverter_unit_id] = self.decoded_common
+
         self.manufacturer = self.decoded_common["C_Manufacturer"]
         self.model = self.decoded_common["C_Model"]
         self.option = self.decoded_common["C_Option"]
@@ -581,6 +584,7 @@ class SolarEdgeMeter:
         self.start_address = None
         self.meter_id = meter_id
         self.has_parent = True
+        self.inverter_common = self.hub.inverter_common[self.inverter_unit_id]
 
         if self.meter_id == 1:
             self.start_address = 40000 + 121
@@ -855,6 +859,7 @@ class SolarEdgeBattery:
         self.start_address = None
         self.battery_id = battery_id
         self.has_parent = True
+        self.inverter_common = self.hub.inverter_common[self.inverter_unit_id]
 
         if self.battery_id == 1:
             self.start_address = 57600

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -683,6 +683,7 @@ class SolarEdgeMeter:
         self.serial = self.decoded_common["C_SerialNumber"]
         self.device_address = self.decoded_common["C_Device_address"]
         self.name = f"{self.hub.hub_id.capitalize()} M{self.meter_id}"
+        self.uid_base = f"{self.model}_{self.serial}"
 
         inverter_model = self.inverter_common["C_Model"]
         inerter_serial = self.inverter_common["C_SerialNumber"]

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -453,6 +453,7 @@ class SolarEdgeInverter:
         self.serial = self.decoded_common["C_SerialNumber"]
         self.device_address = self.decoded_common["C_Device_address"]
         self.name = f"{self.hub.hub_id.capitalize()} I{self.inverter_unit_id}"
+        self.uid_base = f"{self.model}_{self.serial}"
 
         self._device_info = {
             "identifiers": {(DOMAIN, f"{self.model}_{self.serial}")},
@@ -682,6 +683,7 @@ class SolarEdgeMeter:
         self.serial = self.decoded_common["C_SerialNumber"]
         self.device_address = self.decoded_common["C_Device_address"]
         self.name = f"{self.hub.hub_id.capitalize()} M{self.meter_id}"
+        self.uid_base = f"{self.model}_{self.serial}"
 
         self._device_info = {
             "identifiers": {(DOMAIN, f"{self.model}_{self.serial}")},
@@ -947,6 +949,7 @@ class SolarEdgeBattery:
         self.serial = self.decoded_common["B_SerialNumber"]
         self.device_address = self.decoded_common["B_Device_Address"]
         self.name = f"{self.hub.hub_id.capitalize()} B{self.battery_id}"
+        self.uid_base = f"{self.model}_{self.serial}"
 
         self._device_info = {
             "identifiers": {(DOMAIN, f"{self.model}_{self.serial}")},

--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -8,5 +8,5 @@
   "codeowners": ["@WillCodeForCats"],
   "config_flow": true,
   "iot_class": "local_polling",
-  "version": "v2.1.3-pre.4"
+  "version": "v2.2.0-pre.1"
 }

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -241,7 +241,7 @@ class SolarEdgeDevice(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_device"
+        return f"{self._platform.uid_base}_device"
 
     @property
     def name(self) -> str:
@@ -340,7 +340,7 @@ class SerialNumber(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_serial_number"
+        return f"{self._platform.uid_base}_serial_number"
 
     @property
     def name(self) -> str:
@@ -360,7 +360,7 @@ class Manufacturer(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_manufacturer"
+        return f"{self._platform.uid_base}_manufacturer"
 
     @property
     def name(self) -> str:
@@ -380,7 +380,7 @@ class Model(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_model"
+        return f"{self._platform.uid_base}_model"
 
     @property
     def name(self) -> str:
@@ -400,7 +400,7 @@ class Option(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_option"
+        return f"{self._platform.uid_base}_option"
 
     @property
     def name(self) -> str:
@@ -430,7 +430,7 @@ class Version(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_version"
+        return f"{self._platform.uid_base}_version"
 
     @property
     def name(self) -> str:
@@ -450,7 +450,7 @@ class DeviceAddress(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_device_id"
+        return f"{self._platform.uid_base}_device_id"
 
     @property
     def name(self) -> str:
@@ -470,7 +470,7 @@ class DeviceAddressParent(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_parent_device_id"
+        return f"{self._platform.uid_base}_parent_device_id"
 
     @property
     def name(self) -> str:
@@ -490,7 +490,7 @@ class SunspecDID(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_sunspec_device_id"
+        return f"{self._platform.uid_base}_sunspec_device_id"
 
     @property
     def name(self) -> str:
@@ -548,12 +548,9 @@ class ACCurrentSensor(SolarEdgeSensorBase):
     @property
     def unique_id(self) -> str:
         if self._phase is None:
-            return f"{self._platform.model}_{self._platform.serial}_ac_current"
+            return f"{self._platform.uid_base}_ac_current"
         else:
-            return (
-                f"{self._platform.model}_{self._platform.serial}_"
-                f"ac_current_{self._phase.lower()}"
-            )
+            return f"{self._platform.uid_base}_ac_current_{self._phase.lower()}"
 
     @property
     def name(self) -> str:
@@ -614,12 +611,9 @@ class VoltageSensor(SolarEdgeSensorBase):
     @property
     def unique_id(self) -> str:
         if self._phase is None:
-            return f"{self._platform.model}_{self._platform.serial}_ac_voltage"
+            return f"{self._platform.uid_base}_ac_voltage"
         else:
-            return (
-                f"{self._platform.model}_{self._platform.serial}_"
-                f"ac_voltage_{self._phase.lower()}"
-            )
+            return f"{self._platform.uid_base}_ac_voltage_{self._phase.lower()}"
 
     @property
     def name(self) -> str:
@@ -672,12 +666,9 @@ class ACPower(SolarEdgeSensorBase):
     @property
     def unique_id(self) -> str:
         if self._phase is None:
-            return f"{self._platform.model}_{self._platform.serial}_ac_power"
+            return f"{self._platform.uid_base}_ac_power"
         else:
-            return (
-                f"{self._platform.model}_{self._platform.serial}_"
-                f"ac_power_{self._phase.lower()}"
-            )
+            return f"{self._platform.uid_base}_ac_power_{self._phase.lower()}"
 
     @property
     def name(self) -> str:
@@ -724,7 +715,7 @@ class ACFrequency(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_ac_frequency"
+        return f"{self._platform.uid_base}_ac_frequency"
 
     @property
     def name(self) -> str:
@@ -768,12 +759,9 @@ class ACVoltAmp(SolarEdgeSensorBase):
     @property
     def unique_id(self) -> str:
         if self._phase is None:
-            return f"{self._platform.model}_{self._platform.serial}_ac_va"
+            return f"{self._platform.uid_base}_ac_va"
         else:
-            return (
-                f"{self._platform.model}_{self._platform.serial}_"
-                f"ac_va_{self._phase.lower()}"
-            )
+            return f"{self._platform.uid_base}_ac_va_{self._phase.lower()}"
 
     @property
     def name(self) -> str:
@@ -825,22 +813,16 @@ class ACVoltAmpReactive(SolarEdgeSensorBase):
     @property
     def unique_id(self) -> str:
         if self._phase is None:
-            return f"{self._platform.model}_{self._platform.serial}_ac_var"
+            return f"{self._platform.uid_base}_ac_var"
         else:
-            return (
-                f"{self._platform.model}_{self._platform.serial}_"
-                f"ac_var_{self._phase.lower()}"
-            )
+            return f"{self._platform.uid_base}_ac_var_{self._phase.lower()}"
 
     @property
     def name(self) -> str:
         if self._phase is None:
             return f"{self._platform._device_info['name']} AC var"
         else:
-            return (
-                f"{self._platform._device_info['name']} "
-                f"AC var {self._phase.upper()}"
-            )
+            return f"{self._platform._device_info['name']} AC var {self._phase.upper()}"
 
     @property
     def entity_registry_enabled_default(self) -> bool:
@@ -885,12 +867,9 @@ class ACPowerFactor(SolarEdgeSensorBase):
     @property
     def unique_id(self) -> str:
         if self._phase is None:
-            return f"{self._platform.model}_{self._platform.serial}_ac_pf"
+            return f"{self._platform.uid_base}_ac_pf"
         else:
-            return (
-                f"{self._platform.model}_{self._platform.serial}_"
-                f"ac_pf_{self._phase.lower()}"
-            )
+            return f"{self._platform.uid_base}_ac_pf_{self._phase.lower()}"
 
     @property
     def name(self) -> str:
@@ -967,12 +946,9 @@ class ACEnergy(SolarEdgeSensorBase):
     @property
     def unique_id(self) -> str:
         if self._phase is None:
-            return f"{self._platform.model}_{self._platform.serial}_ac_energy_kwh"
+            return f"{self._platform.uid_base}_ac_energy_kwh"
         else:
-            return (
-                f"{self._platform.model}_{self._platform.serial}_"
-                f"{self._phase.lower()}_kwh"
-            )
+            return f"{self._platform.uid_base}_{self._phase.lower()}_kwh"
 
     @property
     def name(self) -> str:
@@ -1029,7 +1005,7 @@ class DCCurrent(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_dc_current"
+        return f"{self._platform.uid_base}_dc_current"
 
     @property
     def name(self) -> str:
@@ -1071,7 +1047,7 @@ class DCVoltage(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_dc_voltage"
+        return f"{self._platform.uid_base}_dc_voltage"
 
     @property
     def name(self) -> str:
@@ -1114,7 +1090,7 @@ class DCPower(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_dc_power"
+        return f"{self._platform.uid_base}_dc_power"
 
     @property
     def name(self) -> str:
@@ -1153,7 +1129,7 @@ class HeatSinkTemperature(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_temp_sink"
+        return f"{self._platform.uid_base}_temp_sink"
 
     @property
     def name(self) -> str:
@@ -1190,7 +1166,7 @@ class Status(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_status"
+        return f"{self._platform.uid_base}_status"
 
     @property
     def name(self) -> str:
@@ -1238,7 +1214,7 @@ class StatusVendor(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_status_vendor"
+        return f"{self._platform.uid_base}_status_vendor"
 
     @property
     def name(self) -> str:
@@ -1285,7 +1261,7 @@ class MeterEvents(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_meter_events"
+        return f"{self._platform.uid_base}_meter_events"
 
     @property
     def name(self) -> str:
@@ -1351,10 +1327,7 @@ class MeterVAhIE(SolarEdgeSensorBase):
         if self._phase is None:
             raise NotImplementedError
         else:
-            return (
-                f"{self._platform.model}_{self._platform.serial}_"
-                f"{self._phase.lower()}_vah"
-            )
+            return f"{self._platform.uid_base}_" f"{self._phase.lower()}_vah"
 
     @property
     def entity_registry_enabled_default(self) -> bool:
@@ -1431,10 +1404,7 @@ class MetervarhIE(SolarEdgeSensorBase):
         if self._phase is None:
             raise NotImplementedError
         else:
-            return (
-                f"{self._platform.model}_{self._platform.serial}_"
-                f"{self._phase.lower()}_varh"
-            )
+            return f"{self._platform.uid_base}_{self._phase.lower()}_varh"
 
     @property
     def entity_registry_enabled_default(self) -> bool:
@@ -1484,7 +1454,7 @@ class MetervarhIE(SolarEdgeSensorBase):
 class SolarEdgeBatteryAvgTemp(HeatSinkTemperature):
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_avg_temp"
+        return f"{self._platform.uid_base}_avg_temp"
 
     @property
     def name(self) -> str:
@@ -1513,7 +1483,7 @@ class SolarEdgeBatteryAvgTemp(HeatSinkTemperature):
 class SolarEdgeBatteryMaxTemp(HeatSinkTemperature):
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_max_temp"
+        return f"{self._platform.uid_base}_max_temp"
 
     @property
     def name(self) -> str:
@@ -1630,7 +1600,7 @@ class SolarEdgeBatteryEnergyExport(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_energy_export"
+        return f"{self._platform.uid_base}_energy_export"
 
     @property
     def name(self) -> str:
@@ -1669,7 +1639,7 @@ class SolarEdgeBatteryEnergyImport(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_energy_import"
+        return f"{self._platform.uid_base}_energy_import"
 
     @property
     def name(self) -> str:
@@ -1706,7 +1676,7 @@ class SolarEdgeBatteryMaxEnergy(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_max_energy"
+        return f"{self._platform.uid_base}_max_energy"
 
     @property
     def name(self) -> str:
@@ -1737,7 +1707,7 @@ class SolarEdgeBatteryAvailableEnergy(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_avail_energy"
+        return f"{self._platform.uid_base}_avail_energy"
 
     @property
     def name(self) -> str:
@@ -1772,7 +1742,7 @@ class SolarEdgeBatterySOH(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_battery_soh"
+        return f"{self._platform.uid_base}_battery_soh"
 
     @property
     def name(self) -> str:
@@ -1804,7 +1774,7 @@ class SolarEdgeBatterySOE(SolarEdgeSensorBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.model}_{self._platform.serial}_battery_soe"
+        return f"{self._platform.uid_base}_battery_soe"
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
This attempts to resolve the issue of duplicate meters appearing after initial setup.

Some inverters do not provide stable meter model and serial number information for unknown reasons. Unfortunately choosing to base the entity Unique ID on either of these values causes new entities to be created if the inverter suddenly reports different values.

The issue has not been observed in the inverter information, so this PR changes the Unique ID for meter entities to be based on the parent inverter's model and serial number.