### PR TITLE
Shut down hub before unloading

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -87,10 +87,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     solaredge_hub = hass.data[DOMAIN][entry.entry_id]["hub"]
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    await solaredge_hub.shutdown()
 
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        await solaredge_hub.shutdown()
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -301,7 +301,7 @@ class SolarEdgeModbusMultiHub:
         self.online = False
         self.disconnect()
         self._client = None
-        await asyncio.sleep(5)
+        await asyncio.sleep(3)
 
     def read_holding_registers(self, unit, address, count):
         """Read holding registers."""


### PR DESCRIPTION
Shut down hub before unloading. Observed a problem while deleting the integration would not actually remove it from the list of configured integrations, and a second delete would cause a home assistant exception requiring a reboot.