### PR TITLE
Sensor registry defaults for single vs. three phase

### DIFF
--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -553,6 +553,21 @@ class ACCurrentSensor(SolarEdgeSensorBase):
             return f"{self._platform.uid_base}_ac_current_{self._phase.lower()}"
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        if self._platform.decoded_model["C_SunSpec_DID"] in [
+            103,
+            203,
+            204,
+        ] and self._phase in [
+            "B",
+            "C",
+        ]:
+            return True
+
+        else:
+            return False
+
+    @property
     def name(self) -> str:
         if self._phase is None:
             return f"{self._platform._device_info['name']} AC Current"
@@ -614,6 +629,23 @@ class VoltageSensor(SolarEdgeSensorBase):
             return f"{self._platform.uid_base}_ac_voltage"
         else:
             return f"{self._platform.uid_base}_ac_voltage_{self._phase.lower()}"
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        if self._platform.decoded_model["C_SunSpec_DID"] in [
+            103,
+            203,
+            204,
+        ] and self._phase in [
+            "BN",
+            "CN",
+            "BC",
+            "CA",
+        ]:
+            return True
+
+        else:
+            return False
 
     @property
     def name(self) -> str:

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -722,6 +722,7 @@ class ACPower(SolarEdgeSensorBase):
             203,
             204,
         ] and self._phase in [
+            "A",
             "B",
             "C",
         ]:

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -554,11 +554,15 @@ class ACCurrentSensor(SolarEdgeSensorBase):
 
     @property
     def entity_registry_enabled_default(self) -> bool:
-        if self._platform.decoded_model["C_SunSpec_DID"] in [
+        if self._phase is None:
+            return True
+
+        elif self._platform.decoded_model["C_SunSpec_DID"] in [
             103,
             203,
             204,
         ] and self._phase in [
+            "A",
             "B",
             "C",
         ]:
@@ -632,15 +636,19 @@ class VoltageSensor(SolarEdgeSensorBase):
 
     @property
     def entity_registry_enabled_default(self) -> bool:
-        if self._platform.decoded_model["C_SunSpec_DID"] in [
+        if self._phase is None:
+            return True
+
+        elif self._platform.decoded_model["C_SunSpec_DID"] in [
             103,
             203,
             204,
         ] and self._phase in [
-            "BN",
-            "CN",
             "BC",
             "CA",
+            "AN",
+            "BN",
+            "CN",
         ]:
             return True
 

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -637,6 +637,9 @@ class VoltageSensor(SolarEdgeSensorBase):
     @property
     def entity_registry_enabled_default(self) -> bool:
         if self._phase is None:
+            raise NotImplementedError
+
+        elif self._phase in ["LN", "LL", "AB"]:
             return True
 
         elif self._platform.decoded_model["C_SunSpec_DID"] in [
@@ -709,6 +712,23 @@ class ACPower(SolarEdgeSensorBase):
             return f"{self._platform.uid_base}_ac_power"
         else:
             return f"{self._platform.uid_base}_ac_power_{self._phase.lower()}"
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        if self._phase is None:
+            return True
+
+        elif self._platform.decoded_model["C_SunSpec_DID"] in [
+            203,
+            204,
+        ] and self._phase in [
+            "B",
+            "C",
+        ]:
+            return True
+
+        else:
+            return False
 
     @property
     def name(self) -> str:
@@ -989,6 +1009,30 @@ class ACEnergy(SolarEdgeSensorBase):
             return f"{self._platform.uid_base}_ac_energy_kwh"
         else:
             return f"{self._platform.uid_base}_{self._phase.lower()}_kwh"
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        if self._phase is None or self._phase in [
+            "Exported",
+            "Imported",
+            "Exported_A",
+            "Imported_A",
+        ]:
+            return True
+
+        elif self._platform.decoded_model["C_SunSpec_DID"] in [
+            203,
+            204,
+        ] and self._phase in [
+            "Exported_B",
+            "Exported_C",
+            "Imported_B",
+            "Imported_C",
+        ]:
+            return True
+
+        else:
+            return False
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
This PR will make sensors that are specific to three phase devices disabled by default on single or split phase devices.