### PR TITLE
Use DeviceInvalid exception for duplicate serial

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -140,7 +140,7 @@ class SolarEdgeModbusMultiHub:
                                     f"on meter 1 inverter {inverter_unit_id}"
                                 ),
                             )
-                            raise DeviceInitFailed(
+                            raise DeviceInvalid(
                                 f"Duplicate m1 serial {new_meter_1.serial}"
                             )
 
@@ -166,7 +166,7 @@ class SolarEdgeModbusMultiHub:
                                     f"on meter 2 inverter {inverter_unit_id}"
                                 ),
                             )
-                            raise DeviceInitFailed(
+                            raise DeviceInvalid(
                                 f"Duplicate m2 serial {new_meter_2.serial}"
                             )
 
@@ -192,7 +192,7 @@ class SolarEdgeModbusMultiHub:
                                     f"on meter 3 inverter {inverter_unit_id}"
                                 ),
                             )
-                            raise DeviceInitFailed(
+                            raise DeviceInvalid(
                                 f"Duplicate m3 serial {new_meter_3.serial}"
                             )
 
@@ -219,7 +219,7 @@ class SolarEdgeModbusMultiHub:
                                     f"on battery 1 inverter {inverter_unit_id}"
                                 ),
                             )
-                            raise DeviceInitFailed(
+                            raise DeviceInvalid(
                                 f"Duplicate b1 serial {new_battery_1.serial}"
                             )
 
@@ -245,7 +245,7 @@ class SolarEdgeModbusMultiHub:
                                     f"on battery 2 inverter {inverter_unit_id}"
                                 ),
                             )
-                            raise DeviceInitFailed(
+                            raise DeviceInvalid(
                                 f"Duplicate b2 serial {new_battery_1.serial}"
                             )
 

--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -8,5 +8,5 @@
   "codeowners": ["@WillCodeForCats"],
   "config_flow": true,
   "iot_class": "local_polling",
-  "version": "v2.2.1"
+  "version": "v2.2.2-pre.1"
 }


### PR DESCRIPTION
Use DeviceInvalid exception for duplicate serial number detection instead of DeviceInitFailed