### PR TITLE
Check keep_modbus_open value in coordinator init

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -111,7 +111,7 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
         )
         self._hub = hub
 
-        if scan_interval < 10:
+        if scan_interval < 10 and not self._hub.keep_modbus_open:
             _LOGGER.warning("Polling frequency < 10, requiring keep modbus open.")
             self._hub.keep_modbus_open = True
 


### PR DESCRIPTION
Suppress warning in logs if option is already enabled.

Fix suggested by @spali