### PR TITLE
Use uid_base for device identifier

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -752,7 +752,7 @@ class SolarEdgeMeter:
         self.uid_base = f"{inverter_model}_{inerter_serial}_M{self.meter_id}"
 
         self._device_info = {
-            "identifiers": {(DOMAIN, f"{self.model}_{self.serial}")},
+            "identifiers": {(DOMAIN, self.uid_base)},
             "name": self.name,
             "manufacturer": self.manufacturer,
             "model": self.model,
@@ -1021,7 +1021,7 @@ class SolarEdgeBattery:
         self.uid_base = f"{inverter_model}_{inerter_serial}_B{self.battery_id}"
 
         self._device_info = {
-            "identifiers": {(DOMAIN, f"{self.model}_{self.serial}")},
+            "identifiers": {(DOMAIN, self.uid_base)},
             "name": self.name,
             "manufacturer": self.manufacturer,
             "model": self.model,


### PR DESCRIPTION
The device ID for meters and batteries should have been updated to match the unique ID change needed to address issue #61, otherwise a device with no entities after integration reload can appear.

This PR corrects an oversight that should have changed this as part of PR #83.