### PR TITLE
Add support for storedge control

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -40,7 +40,7 @@ from .hub import DataUpdateFailed, HubInitFailed, SolarEdgeModbusMultiHub
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = [Platform.SENSOR]
+PLATFORMS: list[str] = [Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -221,3 +221,28 @@ MMPPT_EVENTS = {
     21: "INPUT_UNDER_VOLTAGE",
     22: "INPUT_OVER_CURRENT",
 }
+
+STOREDGE_CONTROL_MODE = {
+    0: "Disabled",
+    1: "Maximize Self Consumption",
+    2: "Time of Use",
+    3: "Backup Only",
+    4: "Remote Control",
+}
+
+STOREDGE_AC_CHARGE_POLICY = {
+    0: "Disabled",
+    1: "Always Allowed",
+    2: "Fixed Energy Limit",
+    3: "Percent of Production",
+}
+
+STOREDGE_MODE = {
+    0: "Off",
+    1: "Charge from excess PV power only",
+    2: "Charge from PV first",
+    3: "Charge from PV and AC",
+    4: "Maximize export",
+    5: "Discharge to match load",
+    7: "Maximize self consumption",
+}

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -424,7 +424,7 @@ class SolarEdgeModbusMultiHub:
     def write_registers(self, unit, address, payload):
         """Write registers."""
         with self._lock:
-            kwargs = {"unit": unit} if unit else {}
+            kwargs = {"slave": unit} if unit else {}
             return self._client.write_registers(address, payload, **kwargs)
 
 
@@ -818,7 +818,7 @@ class SolarEdgeInverter:
                 ]
             )
 
-            for name, value in iteritems(self.decoded_storedge):
+            for name, value in iter(self.decoded_storedge.items()):
                 _LOGGER.debug(
                     (
                         f"Inverter {self.inverter_unit_id}: "

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -421,6 +421,12 @@ class SolarEdgeModbusMultiHub:
             kwargs = {"slave": unit} if unit else {}
             return self._client.read_holding_registers(address, count, **kwargs)
 
+    def write_registers(self, unit, address, payload):
+        """Write registers."""
+        with self._lock:
+            kwargs = {"unit": unit} if unit else {}
+            return self._client.write_registers(address, payload, **kwargs)
+
 
 class SolarEdgeInverter:
     def __init__(self, device_id: int, hub: SolarEdgeModbusMultiHub) -> None:
@@ -429,6 +435,7 @@ class SolarEdgeInverter:
         self.decoded_common = []
         self.decoded_model = []
         self.decoded_mmppt = []
+        self.decoded_storedge = []
         self.has_parent = False
         self.global_power_control = None
         self.advanced_power_control = None
@@ -779,6 +786,49 @@ class SolarEdgeInverter:
                     f"{name} {hex(value) if isinstance(value, int) else value}"
                 ),
             )
+
+        # If a battery is available on this inverter read storage control registers
+        for battery in self.hub.batteries:
+            if self.inverter_unit_id != battery.inverter_unit_id:
+                continue
+
+            # Read the storedge holding registers
+            inverter_data = self.hub.read_holding_registers(
+                unit=self.inverter_unit_id, address=57348, count=14
+            )
+            if inverter_data.isError():
+                _LOGGER.debug(f"Inverter {self.inverter_unit_id}: {inverter_data}")
+                raise ModbusReadError(inverter_data)
+
+            decoder = BinaryPayloadDecoder.fromRegisters(
+                inverter_data.registers, byteorder=Endian.Big, wordorder=Endian.Little
+            )
+
+            self.decoded_storedge = OrderedDict(
+                [
+                    ("control_mode", decoder.decode_16bit_uint()),
+                    ("ac_charge_policy", decoder.decode_16bit_uint()),
+                    ("ac_charge_limit", decoder.decode_32bit_float()),
+                    ("backup_reserved", decoder.decode_32bit_float()),
+                    ("default_mode", decoder.decode_16bit_uint()),
+                    ("remote_command_timeout", decoder.decode_32bit_uint()),
+                    ("remote_command_mode", decoder.decode_16bit_uint()),
+                    ("remote_charge_limit", decoder.decode_32bit_float()),
+                    ("remote_discharge_limit", decoder.decode_32bit_float()),
+                ]
+            )
+
+            for name, value in iteritems(self.decoded_storedge):
+                _LOGGER.debug(
+                    (
+                        f"Inverter {self.inverter_unit_id}: "
+                        f"{name} {hex(value) if isinstance(value, int) else value}"
+                    ),
+                )
+
+    def write_registers(self, address, payload):
+        """Write inverter register."""
+        return self.hub.write_registers(self.inverter_unit_id, address, payload)
 
     @property
     def online(self) -> bool:

--- a/custom_components/solaredge_modbus_multi/number.py
+++ b/custom_components/solaredge_modbus_multi/number.py
@@ -1,0 +1,298 @@
+import logging
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ENERGY_KILO_WATT_HOUR,
+    PERCENTAGE,
+    POWER_WATT,
+    TIME_SECONDS,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from pymodbus.constants import Endian
+from pymodbus.payload import BinaryPayloadBuilder
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+
+    hub = hass.data[DOMAIN][config_entry.entry_id]["hub"]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+
+    entities = []
+
+    # If a battery is available add storage control
+    for battery in hub.batteries:
+        for inverter in hub.inverters:
+            # Skip this inverter if no battery connected to it
+            if inverter.inverter_unit_id != battery.inverter_unit_id:
+                continue
+            entities.append(StoredgeACChargeLimit(inverter, config_entry, coordinator))
+            entities.append(StoredgeBackupReserved(inverter, config_entry, coordinator))
+            entities.append(StoredgeCommandTimeout(inverter, config_entry, coordinator))
+            entities.append(
+                StoredgeChargeLimit(inverter, battery, config_entry, coordinator)
+            )
+            entities.append(
+                StoredgeDischargeLimit(inverter, battery, config_entry, coordinator)
+            )
+
+    async_add_entities(entities)
+    return True
+
+
+def get_key(d, search):
+    for k, v in d.items():
+        if v == search:
+            return k
+    return None
+
+
+class SolarEdgeNumberBase(CoordinatorEntity, NumberEntity):
+    should_poll = False
+    _attr_has_entity_name = True
+    entity_category = EntityCategory.CONFIG
+
+    def __init__(self, platform, config_entry, coordinator):
+        """Pass coordinator to CoordinatorEntity."""
+        super().__init__(coordinator)
+        """Initialize the number."""
+        self._platform = platform
+        self._config_entry = config_entry
+
+    @property
+    def device_info(self):
+        return self._platform.device_info
+
+    @property
+    def config_entry_id(self):
+        return self._config_entry.entry_id
+
+    @property
+    def config_entry_name(self):
+        return self._config_entry.data["name"]
+
+    @property
+    def available(self) -> bool:
+        return self._platform.online
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self.async_write_ha_state()
+
+
+class StoredgeACChargeLimit(SolarEdgeNumberBase):
+    icon = "mdi:lightning-bolt"
+
+    def __init__(self, platform, config_entry, coordinator):
+        super().__init__(platform, config_entry, coordinator)
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_storedge_ac_charge_limit"
+
+    @property
+    def name(self) -> str:
+        return "Storedge AC Charge Limit"
+
+    @property
+    def available(self) -> bool:
+        # Available for AC charge policies 2 & 3
+        return self._platform.online and self._platform.decoded_storedge[
+            "ac_charge_policy"
+        ] in [2, 3]
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        # kWh in AC policy "Fixed Energy Limit", % in AC policy "Percent of Production"
+        if self._platform.decoded_storedge["ac_charge_policy"] == 2:
+            return ENERGY_KILO_WATT_HOUR
+        elif self._platform.decoded_storedge["ac_charge_policy"] == 3:
+            return PERCENTAGE
+        else:
+            return None
+
+    @property
+    def native_min_value(self) -> float:
+        return 0
+
+    @property
+    def native_max_value(self) -> float:
+        # 100MWh in AC policy "Fixed Energy Limit"
+        if self._platform.decoded_storedge["ac_charge_policy"] == 2:
+            return 100000000
+        elif self._platform.decoded_storedge["ac_charge_policy"] == 3:
+            return 100
+        else:
+            return 0
+
+    @property
+    def native_value(self) -> float | None:
+        return round(self._platform.decoded_storedge["ac_charge_limit"], 3)
+
+    async def async_set_native_value(self, value: float) -> None:
+        _LOGGER.debug(f"set {self.unique_id} to {value}")
+        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder.add_32bit_float(float(value))
+        self._platform.write_registers(address=57350, payload=builder.to_registers())
+        await self.async_update()
+
+
+class StoredgeBackupReserved(SolarEdgeNumberBase):
+    icon = "mdi:battery-positive"
+
+    def __init__(self, inverter, config_entry, coordinator):
+        super().__init__(inverter, config_entry, coordinator)
+        self._attr_native_unit_of_measurement = PERCENTAGE
+        self._attr_native_min_value = 0
+        self._attr_native_max_value = 100
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_storedge_backup_reserved"
+
+    @property
+    def name(self) -> str:
+        return "Storedge Backup Reserved"
+
+    @property
+    def native_value(self) -> float | None:
+        return round(self._platform.decoded_storedge["backup_reserved"], 3)
+
+    async def async_set_native_value(self, value: float) -> None:
+        _LOGGER.debug(f"set {self.unique_id} to {value}")
+        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder.add_32bit_float(float(value))
+        self._platform.write_registers(address=57352, payload=builder.to_registers())
+        await self.async_update()
+
+
+class StoredgeCommandTimeout(SolarEdgeNumberBase):
+    icon = "mdi:clock-end"
+
+    def __init__(self, inverter, config_entry, coordinator):
+        super().__init__(inverter, config_entry, coordinator)
+        self._attr_native_min_value = 0
+        self._attr_native_max_value = 86400  # 24h
+        self._attr_native_unit_of_measurement = TIME_SECONDS
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_storedge_remote_command_timeout"
+
+    @property
+    def name(self) -> str:
+        return "Storedge Remote Command Timeout"
+
+    @property
+    def available(self) -> bool:
+        # Available only in remote control mode
+        return (
+            self._platform.online
+            and self._platform.decoded_storedge["control_mode"] == 4
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        return float(self._platform.decoded_storedge["remote_command_timeout"])
+
+    async def async_set_native_value(self, value: float) -> None:
+        _LOGGER.debug(f"set {self.unique_id} to {value}")
+        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder.add_32bit_uint(int(value))
+        self._platform.write_registers(address=57355, payload=builder.to_registers())
+        await self.async_update()
+
+
+class StoredgeChargeLimit(SolarEdgeNumberBase):
+    icon = "mdi:lightning-bolt"
+
+    def __init__(self, inverter, battery, config_entry, coordinator):
+        super().__init__(inverter, config_entry, coordinator)
+        self._battery = battery
+        self._attr_native_min_value = 0
+        self._attr_native_unit_of_measurement = POWER_WATT
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_storedge_remote_charge_limit"
+
+    @property
+    def name(self) -> str:
+        return "Storedge Remote Charge Limit"
+
+    @property
+    def available(self) -> bool:
+        # Available only in remote control mode
+        return (
+            self._platform.online
+            and self._platform.decoded_storedge["control_mode"] == 4
+        )
+
+    @property
+    def native_max_value(self) -> float:
+        # Return batterys max charge power
+        return self._battery.decoded_common["B_MaxChargePower"]
+
+    @property
+    def native_value(self) -> float | None:
+        return round(self._platform.decoded_storedge["remote_charge_limit"], 3)
+
+    async def async_set_native_value(self, value: float) -> None:
+        _LOGGER.debug(f"set {self.unique_id} to {value}")
+        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder.add_32bit_float(float(value))
+        self._platform.write_registers(address=57358, payload=builder.to_registers())
+        await self.async_update()
+
+
+class StoredgeDischargeLimit(SolarEdgeNumberBase):
+    icon = "mdi:lightning-bolt"
+
+    def __init__(self, inverter, battery, config_entry, coordinator):
+        super().__init__(inverter, config_entry, coordinator)
+        self._battery = battery
+        self._attr_native_min_value = 0
+        self._attr_native_unit_of_measurement = POWER_WATT
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_storedge_remote_discharge_limit"
+
+    @property
+    def name(self) -> str:
+        return "Storedge Remote Discharge Limit"
+
+    @property
+    def available(self) -> bool:
+        # Available only in remote control mode
+        return (
+            self._platform.online
+            and self._platform.decoded_storedge["control_mode"] == 4
+        )
+
+    @property
+    def native_max_value(self) -> float:
+        # Return batterys max discharge power
+        return self._battery.decoded_common["B_MaxDischargePower"]
+
+    @property
+    def native_value(self) -> float | None:
+        return round(self._platform.decoded_storedge["remote_discharge_limit"], 3)
+
+    async def async_set_native_value(self, value: float) -> None:
+        _LOGGER.debug(f"set {self.unique_id} to {value}")
+        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder.add_32bit_float(float(value))
+        self._platform.write_registers(address=57360, payload=builder.to_registers())
+        await self.async_update()

--- a/custom_components/solaredge_modbus_multi/select.py
+++ b/custom_components/solaredge_modbus_multi/select.py
@@ -1,0 +1,203 @@
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    DOMAIN,
+    STOREDGE_AC_CHARGE_POLICY,
+    STOREDGE_CONTROL_MODE,
+    STOREDGE_MODE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+
+    hub = hass.data[DOMAIN][config_entry.entry_id]["hub"]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+
+    entities = []
+
+    # If a battery is available add storage control
+    for battery in hub.batteries:
+        for inverter in hub.inverters:
+            # Skip this inverter if no battery connected to it
+            if inverter.inverter_unit_id != battery.inverter_unit_id:
+                continue
+            entities.append(StoredgeControlMode(inverter, config_entry, coordinator))
+            entities.append(StoredgeACChargePolicy(inverter, config_entry, coordinator))
+            entities.append(StoredgeDefaultMode(inverter, config_entry, coordinator))
+            entities.append(StoredgeRemoteMode(inverter, config_entry, coordinator))
+
+    async_add_entities(entities)
+    return True
+
+
+def get_key(d, search):
+    for k, v in d.items():
+        if v == search:
+            return k
+    return None
+
+
+class SolarEdgeSelectBase(CoordinatorEntity, SelectEntity):
+    should_poll = False
+    _attr_has_entity_name = True
+    entity_category = EntityCategory.CONFIG
+
+    def __init__(self, platform, config_entry, coordinator):
+        """Pass coordinator to CoordinatorEntity."""
+        super().__init__(coordinator)
+        """Initialize the sensor."""
+        self._platform = platform
+        self._config_entry = config_entry
+
+    @property
+    def device_info(self):
+        return self._platform.device_info
+
+    @property
+    def config_entry_id(self):
+        return self._config_entry.entry_id
+
+    @property
+    def config_entry_name(self):
+        return self._config_entry.data["name"]
+
+    @property
+    def available(self) -> bool:
+        return self._platform.online
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self.async_write_ha_state()
+
+
+class StoredgeControlMode(SolarEdgeSelectBase):
+    def __init__(self, platform, config_entry, coordinator):
+        super().__init__(platform, config_entry, coordinator)
+        self._options = STOREDGE_CONTROL_MODE
+        self._attr_options = list(self._options.values())
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_storedge_control_mode"
+
+    @property
+    def name(self) -> str:
+        return "Storedge Control Mode"
+
+    @property
+    def current_option(self) -> str:
+        return self._options[self._platform.decoded_storedge["control_mode"]]
+
+    async def async_select_option(self, option: str) -> None:
+        _LOGGER.debug(f"set {self.unique_id} to {option}")
+        new_mode = get_key(self._options, option)
+        self._platform.write_registers(address=57348, payload=new_mode)
+        await self.async_update()
+
+
+class StoredgeACChargePolicy(SolarEdgeSelectBase):
+    def __init__(self, platform, config_entry, coordinator):
+        super().__init__(platform, config_entry, coordinator)
+        self._options = STOREDGE_AC_CHARGE_POLICY
+        self._attr_options = list(self._options.values())
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_storedge_ac_charge_policy"
+
+    @property
+    def name(self) -> str:
+        return "AC Charge Policy"
+
+    @property
+    def current_option(self) -> str:
+        return self._options[self._platform.decoded_storedge["ac_charge_policy"]]
+
+    async def async_select_option(self, option: str) -> None:
+        _LOGGER.debug(f"set {self.unique_id} to {option}")
+        new_mode = get_key(self._options, option)
+        self._platform.write_registers(address=57349, payload=new_mode)
+        await self.async_update()
+
+
+class StoredgeDefaultMode(SolarEdgeSelectBase):
+    def __init__(self, platform, config_entry, coordinator):
+        super().__init__(platform, config_entry, coordinator)
+        self._options = STOREDGE_MODE
+        self._attr_options = list(self._options.values())
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_storedge_default_mode"
+
+    @property
+    def name(self) -> str:
+        return "Storedge Default Mode"
+
+    @property
+    def available(self) -> bool:
+        # Available only in remote control mode
+        return (
+            self._platform.online
+            and self._platform.decoded_storedge["control_mode"] == 4
+        )
+
+    @property
+    def current_option(self) -> str:
+        return self._options[self._platform.decoded_storedge["default_mode"]]
+
+    async def async_select_option(self, option: str) -> None:
+        _LOGGER.debug(f"set {self.unique_id} to {option}")
+        new_mode = get_key(self._options, option)
+        self._platform.write_registers(address=57354, payload=new_mode)
+        await self.async_update()
+
+
+class StoredgeRemoteMode(SolarEdgeSelectBase):
+    def __init__(self, platform, config_entry, coordinator):
+        super().__init__(platform, config_entry, coordinator)
+        self._options = STOREDGE_MODE
+        self._attr_options = list(self._options.values())
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_storedge_remote_mode"
+
+    @property
+    def name(self) -> str:
+        return "Storedge Remote Mode"
+
+    @property
+    def available(self) -> bool:
+        # Available only in remote control mode
+        return (
+            self._platform.online
+            and self._platform.decoded_storedge["control_mode"] == 4
+        )
+
+    @property
+    def current_option(self) -> str:
+        try:
+            return self._options[self._platform.decoded_storedge["remote_command_mode"]]
+        except KeyError:
+            return STATE_UNKNOWN
+
+    async def async_select_option(self, option: str) -> None:
+        _LOGGER.debug(f"set {self.unique_id} to {option}")
+        new_mode = get_key(self._options, option)
+        self._platform.write_registers(address=57357, payload=new_mode)
+        await self.async_update()


### PR DESCRIPTION
Add support for control of the "storedge control block" in SolarEdge inverters. This block is at address 0xE004-0xE011 inclusive (decimal 57348-57371). The block contains registers which allow configuration of the behaviour of any batteries connected to the inverter, such as forcing charge/discharge modes, enabling/disabling charging from AC, etc.

For any inverters that have batteries connected, create select and number entities to allow interaction with these controls.

This PR is similar to the one I did for the original version of this component https://github.com/binsentsu/home-assistant-solaredge-modbus/pull/38 - but due to the many improvements made by @WillCodeForCats this version is much better:
- Dynamic availability of controls based up selected modes
- Proper limits for number controls based on known data

This works fine on my system - a single SE3680 Inverter with a single LG RESU7H Battery. Review of the code and of course testing on systems with multiple inverters, multiple batteries, etc would be very welcome.