### PR TITLE
Increase coordinator timeout to 30 seconds

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -165,7 +165,7 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         try:
-            async with async_timeout.timeout(5):
+            async with async_timeout.timeout(30):
                 return await self._hub.async_refresh_modbus_data()
 
         except HubInitFailed as e:


### PR DESCRIPTION
Some inverters may not respond as quickly as others to all the things we ask during setup or not at all (which triggers modbus timeout), requiring a longer timeout at the coordinator level, especially with higher inverter counts.