### PR TITLE
Remove battery enabled warning

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -123,14 +123,6 @@ class SolarEdgeModbusMultiHub:
         if not self.is_socket_open():
             raise HubInitFailed(f"Could not open Modbus/TCP connection to {self._host}")
 
-        if self._detect_batteries:
-            _LOGGER.warning(
-                (
-                    "Battery registers not officially supported by SolarEdge. "
-                    "Use at your own risk!"
-                ),
-            )
-
         if self._adv_storedge_control:
             _LOGGER.warning(
                 (


### PR DESCRIPTION
This warning is redundant and superseded by the warnings added in PR #149

Known issues with battery stuff is covered in the wiki.

Replaces PR #150