### PR TITLE
Advanced Power Control binary sensor

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -40,7 +40,13 @@ from .hub import DataUpdateFailed, HubInitFailed, SolarEdgeModbusMultiHub
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = [Platform.BINARY_SENSOR,, Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
+PLATFORMS: list[str] = [
+    Platform.BINARY_SENSOR,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+]
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up SolarEdge Modbus from a config entry."""

--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -40,8 +40,7 @@ from .hub import DataUpdateFailed, HubInitFailed, SolarEdgeModbusMultiHub
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = [Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
-
+PLATFORMS: list[str] = [Platform.BINARY_SENSOR,, Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up SolarEdge Modbus from a config entry."""

--- a/custom_components/solaredge_modbus_multi/binary_sensor.py
+++ b/custom_components/solaredge_modbus_multi/binary_sensor.py
@@ -87,7 +87,10 @@ class AdvPowerControlEnabled(SolarEdgeBinarySensorBase):
 
     @property
     def available(self) -> bool:
-        if self._platform.advanced_power_control is True:
+        if (
+            self._platform.online is True
+            and self._platform.advanced_power_control is True
+        ):
             return True
 
         else:

--- a/custom_components/solaredge_modbus_multi/binary_sensor.py
+++ b/custom_components/solaredge_modbus_multi/binary_sensor.py
@@ -1,0 +1,105 @@
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+
+    hub = hass.data[DOMAIN][config_entry.entry_id]["hub"]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+
+    entities = []
+
+    for inverter in hub.inverters:
+        entities.append(AdvPowerControlEnabled(inverter, config_entry, coordinator))
+
+    if entities:
+        async_add_entities(entities)
+
+
+class SolarEdgeBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
+    should_poll = False
+    _attr_has_entity_name = True
+
+    def __init__(self, platform, config_entry, coordinator):
+        """Pass coordinator to CoordinatorEntity."""
+        super().__init__(coordinator)
+        """Initialize the sensor."""
+        self._platform = platform
+        self._config_entry = config_entry
+
+    @property
+    def device_info(self):
+        return self._platform.device_info
+
+    @property
+    def config_entry_id(self):
+        return self._config_entry.entry_id
+
+    @property
+    def config_entry_name(self):
+        return self._config_entry.data["name"]
+
+    @property
+    def available(self) -> bool:
+        return self._platform.online
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self.async_write_ha_state()
+
+
+class AdvPowerControlEnabled(SolarEdgeBinarySensorBase):
+    entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, platform, config_entry, coordinator):
+        super().__init__(platform, config_entry, coordinator)
+        """Initialize the sensor."""
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_adv_pwr_ctrl_en"
+
+    @property
+    def name(self) -> str:
+        return "Advanced Power Control"
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        if self._platform.advanced_power_control is True:
+            return True
+
+        else:
+            return False
+
+    @property
+    def available(self) -> bool:
+        if self._platform.advanced_power_control is True:
+            return True
+
+        else:
+            return False
+
+    @property
+    def is_on(self):
+        try:
+            if self._platform.decoded_model["I_AdvPwrCtrlEn"] == 0x1:
+                return True
+            else:
+                return False
+
+        except KeyError:
+            return None


### PR DESCRIPTION
Adds sensor to show status of advanced power control. Not 100% sure if this should be implemented as a binary sensor, as a switch, or both.

Right now leaning towards always show the binary sensor and then only show the switch if advanced power control is enabled in options.