### PR TITLE
Remove disconnect call after write

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -457,9 +457,6 @@ class SolarEdgeModbusMultiHub:
             self.disconnect()
 
         else:
-            if not self._keep_modbus_open:
-                self.disconnect()
-
             if result.isError():
                 raise ModbusWriteError(result)
 


### PR DESCRIPTION
Commands will request a refresh immediately but it's possible this happens too fast for real inverters and they reject the connection, whereas it works fine in my simulator.