### PR TITLE
Bump pymodbus to 3.0.2

### DIFF
--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -3,7 +3,7 @@
   "name": "SolarEdge Modbus Multi Device",
   "documentation": "https://github.com/WillCodeForCats/solaredge-modbus-multi/wiki",
   "issue_tracker": "https://github.com/WillCodeForCats/solaredge-modbus-multi/issues",
-  "requirements": ["pymodbus==3.0.1"],
+  "requirements": ["pymodbus==3.0.2"],
   "dependencies": [],
   "codeowners": ["@WillCodeForCats"],
   "config_flow": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymodbus==3.0.1
+pymodbus==3.0.2


### PR DESCRIPTION
pymodbus 3.0.1 was flagged as a faulty release.