### PR TITLE
Log warning for depreciated sensors if enabled

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -143,6 +143,15 @@ class SolarEdgeModbusMultiHub:
                 ),
             )
 
+        if not self._single_device_entity:
+            _LOGGER.warning(
+                (
+                    "Static information sensors are depreciated and may be removed "
+                    "in a future release. Use attributes from the 'Device' sensor. "
+                    "https://github.com/WillCodeForCats/solaredge-modbus-multi/discussions/168"  # noqa: E501
+                ),
+            )
+
         for inverter_index in range(self._number_of_inverters):
             inverter_unit_id = inverter_index + self._start_device_id
 


### PR DESCRIPTION
Logs a warning if depreciated sensors (see discussion #168) are enabled.

No change to defaults, the default behavior is to only use the single "Device" entity.