### PR TITLE
Update meter related names

### DIFF
--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -252,8 +252,8 @@ STOREDGE_MODE = {
 
 LIMIT_CONTROL_MODE = {
     None: "Disabled",
-    0: "Using Export/Import Meter",
-    1: "Using Consumption Meter",
+    0: "Export Using Export/Import Meter",
+    1: "Export Using Consumption Meter",
     2: "Production Limitation",
 }
 

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -252,9 +252,9 @@ STOREDGE_MODE = {
 
 LIMIT_CONTROL_MODE = {
     None: "Disabled",
-    0: "Export Using Export/Import Meter",
-    1: "Export Using Consumption Meter",
-    2: "Production Limitation",
+    0: "Export Control (Export/Import Meter)",
+    1: "Export Control (Consumption Meter)",
+    2: "Production Control",
 }
 
 LIMIT_CONTROL = {0: "Total", 1: "Per Phase"}

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -252,8 +252,8 @@ STOREDGE_MODE = {
 
 LIMIT_CONTROL_MODE = {
     None: "Disabled",
-    0: "Export/Import Meter",
-    1: "Consumption Meter",
+    0: "Using Export/Import Meter",
+    1: "Using Consumption Meter",
     2: "Production Limitation",
 }
 

--- a/custom_components/solaredge_modbus_multi/number.py
+++ b/custom_components/solaredge_modbus_multi/number.py
@@ -343,7 +343,11 @@ class SolarEdgeExportSiteLimit(SolarEdgeNumberBase):
 
     @property
     def native_value(self) -> float | None:
-        return round(self._platform.decoded_model["E_Site_Limit"], 1)
+        try:
+            return round(self._platform.decoded_model["E_Site_Limit"], 1)
+
+        except KeyError:
+            return None
 
     async def async_set_native_value(self, value: float) -> None:
         _LOGGER.debug(f"set {self.unique_id} to {value}")
@@ -378,7 +382,11 @@ class SolarEdgeExternalProductionMax(SolarEdgeNumberBase):
 
     @property
     def native_value(self) -> float | None:
-        return round(self._platform.decoded_model["Ext_Prod_Max"], 1)
+        try:
+            return round(self._platform.decoded_model["Ext_Prod_Max"], 1)
+
+        except KeyError:
+            return None
 
     async def async_set_native_value(self, value: float) -> None:
         _LOGGER.debug(f"set {self.unique_id} to {value}")

--- a/custom_components/solaredge_modbus_multi/number.py
+++ b/custom_components/solaredge_modbus_multi/number.py
@@ -325,7 +325,7 @@ class StoredgeDischargeLimit(SolarEdgeNumberBase):
 
 
 class SolarEdgeExportSiteLimit(SolarEdgeNumberBase):
-    icon = "mdi:transmission-tower-import"
+    icon = "mdi:lightning-bolt"
 
     def __init__(self, inverter, config_entry, coordinator):
         super().__init__(inverter, config_entry, coordinator)


### PR DESCRIPTION
Meter modes are selecting which meter type to use for calculating export limitation, change names to reflect that.

[Adjust limit control names closer to SetApp names](https://github.com/WillCodeForCats/solaredge-modbus-multi/pull/181/commits/6bb47a2350f275b41e00538f29b36961665bb899)