### PR TITLE
Battery energy in zero state behavior

### DIFF
--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1917,7 +1917,10 @@ class SolarEdgeBatteryEnergyExport(SolarEdgeSensorBase):
     @property
     def native_value(self):
         try:
-            if self._platform.decoded_model["B_Export_Energy_WH"] == 0xFFFFFFFFFFFFFFFF:
+            if (
+                self._platform.decoded_model["B_Export_Energy_WH"] == 0xFFFFFFFFFFFFFFFF
+                or self._platform.decoded_model["B_Export_Energy_WH"] == 0x0
+            ):
                 return None
 
             else:
@@ -1979,7 +1982,10 @@ class SolarEdgeBatteryEnergyImport(SolarEdgeSensorBase):
     @property
     def native_value(self):
         try:
-            if self._platform.decoded_model["B_Import_Energy_WH"] == 0xFFFFFFFFFFFFFFFF:
+            if (
+                self._platform.decoded_model["B_Import_Energy_WH"] == 0xFFFFFFFFFFFFFFFF
+                or self._platform.decoded_model["B_Import_Energy_WH"] == 0x0
+            ):
                 return None
 
             else:


### PR DESCRIPTION
Other accumulator data for meters and inverters goes unavailable when zero (i.e. "not accumulated" state per sunspec), extend the same behavior to battery energy accumulators.