### PR TITLE
Config flow cleanup

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -16,28 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
-    CONF_ADV_PWR_CONTROL,
-    CONF_ADV_SITE_LIMIT_CONTROL,
-    CONF_ADV_STORAGE_CONTROL,
-    CONF_ALLOW_BATTERY_ENERGY_RESET,
-    CONF_DETECT_BATTERIES,
-    CONF_DETECT_METERS,
-    CONF_DEVICE_ID,
-    CONF_KEEP_MODBUS_OPEN,
-    CONF_NUMBER_INVERTERS,
-    CONF_SINGLE_DEVICE_ENTITY,
-    DEFAULT_ADV_PWR_CONTROL,
-    DEFAULT_ADV_SITE_LIMIT_CONTROL,
-    DEFAULT_ADV_STORAGE_CONTROL,
-    DEFAULT_ALLOW_BATTERY_ENERGY_RESET,
-    DEFAULT_DETECT_BATTERIES,
-    DEFAULT_DETECT_METERS,
-    DEFAULT_KEEP_MODBUS_OPEN,
-    DEFAULT_SCAN_INTERVAL,
-    DEFAULT_SINGLE_DEVICE_ENTITY,
-    DOMAIN,
-)
+from .const import DOMAIN, ConfDefaultFlag, ConfDefaultInt, ConfName
 from .hub import DataUpdateFailed, HubInitFailed, SolarEdgeModbusMultiHub
 
 _LOGGER = logging.getLogger(__name__)
@@ -70,24 +49,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data[CONF_NAME],
         entry.data[CONF_HOST],
         entry.data[CONF_PORT],
-        entry.data.get(CONF_NUMBER_INVERTERS, 1),
-        entry.data.get(CONF_DEVICE_ID, 1),
-        entry.options.get(CONF_DETECT_METERS, DEFAULT_DETECT_METERS),
-        entry.options.get(CONF_DETECT_BATTERIES, DEFAULT_DETECT_BATTERIES),
-        entry.options.get(CONF_SINGLE_DEVICE_ENTITY, DEFAULT_SINGLE_DEVICE_ENTITY),
-        entry.options.get(CONF_KEEP_MODBUS_OPEN, DEFAULT_KEEP_MODBUS_OPEN),
-        entry.options.get(CONF_ADV_PWR_CONTROL, DEFAULT_ADV_PWR_CONTROL),
-        entry.options.get(CONF_ADV_STORAGE_CONTROL, DEFAULT_ADV_STORAGE_CONTROL),
-        entry.options.get(CONF_ADV_SITE_LIMIT_CONTROL, DEFAULT_ADV_SITE_LIMIT_CONTROL),
+        entry.data.get(ConfName.NUMBER_INVERTERS, ConfDefaultInt.NUMBER_INVERTERS),
+        entry.data.get(ConfName.DEVICE_ID, ConfDefaultInt.DEVICE_ID),
+        entry.options.get(ConfName.DETECT_METERS, ConfDefaultFlag.DETECT_METERS),
+        entry.options.get(ConfName.DETECT_BATTERIES, ConfDefaultFlag.DETECT_BATTERIES),
         entry.options.get(
-            CONF_ALLOW_BATTERY_ENERGY_RESET, DEFAULT_ALLOW_BATTERY_ENERGY_RESET
+            ConfName.SINGLE_DEVICE_ENTITY, ConfDefaultFlag.SINGLE_DEVICE_ENTITY
+        ),
+        entry.options.get(ConfName.KEEP_MODBUS_OPEN, ConfDefaultFlag.KEEP_MODBUS_OPEN),
+        entry.options.get(ConfName.ADV_PWR_CONTROL, ConfDefaultFlag.ADV_PWR_CONTROL),
+        entry.options.get(
+            ConfName.ADV_STORAGE_CONTROL, ConfDefaultFlag.ADV_STORAGE_CONTROL
+        ),
+        entry.options.get(
+            ConfName.ADV_SITE_LIMIT_CONTROL, ConfDefaultFlag.ADV_SITE_LIMIT_CONTROL
+        ),
+        entry.options.get(
+            ConfName.ALLOW_BATTERY_ENERGY_RESET,
+            ConfDefaultFlag.ALLOW_BATTERY_ENERGY_RESET,
         ),
     )
 
     coordinator = SolarEdgeCoordinator(
         hass,
         solaredge_hub,
-        entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+        entry.options.get(CONF_SCAN_INTERVAL, ConfDefaultInt.SCAN_INTERVAL),
     )
 
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -34,6 +34,9 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SINGLE_DEVICE_ENTITY,
     DOMAIN,
+    ConfDefaultFlag,
+    ConfDefaultInt,
+    ConfDefaultName,
 )
 
 

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -99,11 +99,11 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         int
                     ),
                     vol.Required(
-                        ConfName.NUMBER_INVERTERS,
+                        f"{ConfName.NUMBER_INVERTERS}",
                         default=user_input[ConfName.NUMBER_INVERTERS],
                     ): vol.Coerce(int),
                     vol.Required(
-                        ConfName.DEVICE_ID, default=user_input[ConfName.DEVICE_ID]
+                        f"{ConfName.DEVICE_ID}", default=user_input[ConfName.DEVICE_ID]
                     ): vol.Coerce(int),
                 },
             ),
@@ -168,27 +168,27 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
                         default=user_input[CONF_SCAN_INTERVAL],
                     ): vol.Coerce(int),
                     vol.Optional(
-                        ConfName.SINGLE_DEVICE_ENTITY,
+                        f"{ConfName.SINGLE_DEVICE_ENTITY}",
                         default=user_input[ConfName.SINGLE_DEVICE_ENTITY],
                     ): cv.boolean,
                     vol.Optional(
-                        ConfName.KEEP_MODBUS_OPEN,
+                        f"{ConfName.KEEP_MODBUS_OPEN}",
                         default=user_input[ConfName.KEEP_MODBUS_OPEN],
                     ): cv.boolean,
                     vol.Optional(
-                        ConfName.DETECT_METERS,
+                        f"{ConfName.DETECT_METERS}",
                         default=user_input[ConfName.DETECT_METERS],
                     ): cv.boolean,
                     vol.Optional(
-                        ConfName.DETECT_BATTERIES,
+                        f"{ConfName.DETECT_BATTERIES}",
                         default=user_input[ConfName.DETECT_BATTERIES],
                     ): cv.boolean,
                     vol.Optional(
-                        ConfName.ADV_PWR_CONTROL,
+                        f"{ConfName.ADV_PWR_CONTROL}",
                         default=user_input[ConfName.ADV_PWR_CONTROL],
                     ): cv.boolean,
                     vol.Optional(
-                        ConfName.ALLOW_BATTERY_ENERGY_RESET,
+                        f"{ConfName.ALLOW_BATTERY_ENERGY_RESET}",
                         default=user_input[ConfName.ALLOW_BATTERY_ENERGY_RESET],
                     ): cv.boolean,
                 },
@@ -221,11 +221,11 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        ConfName.ADV_STORAGE_CONTROL,
+                        f"{ConfName.ADV_STORAGE_CONTROL}",
                         default=user_input[ConfName.ADV_STORAGE_CONTROL],
                     ): cv.boolean,
                     vol.Required(
-                        ConfName.ADV_SITE_LIMIT_CONTROL,
+                        f"{ConfName.ADV_SITE_LIMIT_CONTROL}",
                         default=user_input[ConfName.ADV_SITE_LIMIT_CONTROL],
                     ): cv.boolean,
                 }

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -9,35 +9,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_SCAN_INTER
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import (
-    CONF_ADV_PWR_CONTROL,
-    CONF_ADV_SITE_LIMIT_CONTROL,
-    CONF_ADV_STORAGE_CONTROL,
-    CONF_ALLOW_BATTERY_ENERGY_RESET,
-    CONF_DETECT_BATTERIES,
-    CONF_DETECT_METERS,
-    CONF_DEVICE_ID,
-    CONF_KEEP_MODBUS_OPEN,
-    CONF_NUMBER_INVERTERS,
-    CONF_SINGLE_DEVICE_ENTITY,
-    DEFAULT_ADV_PWR_CONTROL,
-    DEFAULT_ADV_SITE_LIMIT_CONTROL,
-    DEFAULT_ADV_STORAGE_CONTROL,
-    DEFAULT_ALLOW_BATTERY_ENERGY_RESET,
-    DEFAULT_DETECT_BATTERIES,
-    DEFAULT_DETECT_METERS,
-    DEFAULT_DEVICE_ID,
-    DEFAULT_KEEP_MODBUS_OPEN,
-    DEFAULT_NAME,
-    DEFAULT_NUMBER_INVERTERS,
-    DEFAULT_PORT,
-    DEFAULT_SCAN_INTERVAL,
-    DEFAULT_SINGLE_DEVICE_ENTITY,
-    DOMAIN,
-    ConfDefaultFlag,
-    ConfDefaultInt,
-    ConfDefaultName,
-)
+from .const import DEFAULT_NAME, DOMAIN, ConfDefaultFlag, ConfDefaultInt, ConfName
 
 
 def host_valid(host):
@@ -89,16 +61,19 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors[CONF_PORT] = "invalid_tcp_port"
             elif user_input[CONF_PORT] > 65535:
                 errors[CONF_PORT] = "invalid_tcp_port"
-            elif user_input[CONF_DEVICE_ID] > 247:
-                errors[CONF_DEVICE_ID] = "max_device_id"
-            elif user_input[CONF_DEVICE_ID] < 1:
-                errors[CONF_DEVICE_ID] = "min_device_id"
-            elif user_input[CONF_NUMBER_INVERTERS] > 32:
-                errors[CONF_NUMBER_INVERTERS] = "max_inverters"
-            elif user_input[CONF_NUMBER_INVERTERS] < 1:
-                errors[CONF_NUMBER_INVERTERS] = "min_inverters"
-            elif user_input[CONF_NUMBER_INVERTERS] + user_input[CONF_DEVICE_ID] > 247:
-                errors[CONF_NUMBER_INVERTERS] = "too_many_inverters"
+            elif user_input[ConfName.DEVICE_ID] > 247:
+                errors[ConfName.DEVICE_ID] = "max_device_id"
+            elif user_input[ConfName.DEVICE_ID] < 1:
+                errors[ConfName.DEVICE_ID] = "min_device_id"
+            elif user_input[ConfName.NUMBER_INVERTERS] > 32:
+                errors[ConfName.NUMBER_INVERTERS] = "max_inverters"
+            elif user_input[ConfName.NUMBER_INVERTERS] < 1:
+                errors[ConfName.NUMBER_INVERTERS] = "min_inverters"
+            elif (
+                user_input[ConfName.NUMBER_INVERTERS] + user_input[ConfName.DEVICE_ID]
+                > 247
+            ):
+                errors[ConfName.NUMBER_INVERTERS] = "too_many_inverters"
             else:
                 await self.async_set_unique_id(user_input[CONF_HOST])
                 self._abort_if_unique_id_configured()
@@ -109,9 +84,9 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user_input = {
                 CONF_NAME: DEFAULT_NAME,
                 CONF_HOST: "",
-                CONF_PORT: DEFAULT_PORT,
-                CONF_NUMBER_INVERTERS: DEFAULT_NUMBER_INVERTERS,
-                CONF_DEVICE_ID: DEFAULT_DEVICE_ID,
+                CONF_PORT: ConfDefaultInt.PORT,
+                ConfName.NUMBER_INVERTERS: ConfDefaultInt.NUMBER_INVERTERS,
+                ConfName.DEVICE_ID: ConfDefaultInt.DEVICE_ID,
             }
 
         return self.async_show_form(
@@ -124,11 +99,11 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         int
                     ),
                     vol.Required(
-                        CONF_NUMBER_INVERTERS,
-                        default=user_input[CONF_NUMBER_INVERTERS],
+                        ConfName.NUMBER_INVERTERS,
+                        default=user_input[ConfName.NUMBER_INVERTERS],
                     ): vol.Coerce(int),
                     vol.Required(
-                        CONF_DEVICE_ID, default=user_input[CONF_DEVICE_ID]
+                        ConfName.DEVICE_ID, default=user_input[ConfName.DEVICE_ID]
                     ): vol.Coerce(int),
                 },
             ),
@@ -152,7 +127,7 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
             elif user_input[CONF_SCAN_INTERVAL] > 86400:
                 errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
             else:
-                if user_input[CONF_ADV_PWR_CONTROL] is True:
+                if user_input[ConfName.ADV_PWR_CONTROL] is True:
                     self.init_info = user_input
                     return await self.async_step_adv_pwr_ctl()
                 else:
@@ -161,25 +136,26 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
         else:
             user_input = {
                 CONF_SCAN_INTERVAL: self.config_entry.options.get(
-                    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                    CONF_SCAN_INTERVAL, ConfDefaultInt.SCAN_INTERVAL
                 ),
-                CONF_SINGLE_DEVICE_ENTITY: self.config_entry.options.get(
-                    CONF_SINGLE_DEVICE_ENTITY, DEFAULT_SINGLE_DEVICE_ENTITY
+                ConfName.SINGLE_DEVICE_ENTITY: self.config_entry.options.get(
+                    ConfName.SINGLE_DEVICE_ENTITY, ConfDefaultFlag.SINGLE_DEVICE_ENTITY
                 ),
-                CONF_KEEP_MODBUS_OPEN: self.config_entry.options.get(
-                    CONF_KEEP_MODBUS_OPEN, DEFAULT_KEEP_MODBUS_OPEN
+                ConfName.KEEP_MODBUS_OPEN: self.config_entry.options.get(
+                    ConfName.KEEP_MODBUS_OPEN, ConfDefaultFlag.KEEP_MODBUS_OPEN
                 ),
-                CONF_DETECT_METERS: self.config_entry.options.get(
-                    CONF_DETECT_METERS, DEFAULT_DETECT_METERS
+                ConfName.DETECT_METERS: self.config_entry.options.get(
+                    ConfName.DETECT_METERS, ConfDefaultFlag.DETECT_METERS
                 ),
-                CONF_DETECT_BATTERIES: self.config_entry.options.get(
-                    CONF_DETECT_BATTERIES, DEFAULT_DETECT_BATTERIES
+                ConfName.DETECT_BATTERIES: self.config_entry.options.get(
+                    ConfName.DETECT_BATTERIES, ConfDefaultFlag.DETECT_BATTERIES
                 ),
-                CONF_ADV_PWR_CONTROL: self.config_entry.options.get(
-                    CONF_ADV_PWR_CONTROL, DEFAULT_ADV_PWR_CONTROL
+                ConfName.ADV_PWR_CONTROL: self.config_entry.options.get(
+                    ConfName.ADV_PWR_CONTROL, ConfDefaultFlag.ADV_PWR_CONTROL
                 ),
-                CONF_ALLOW_BATTERY_ENERGY_RESET: self.config_entry.options.get(
-                    CONF_ALLOW_BATTERY_ENERGY_RESET, DEFAULT_ALLOW_BATTERY_ENERGY_RESET
+                ConfName.ALLOW_BATTERY_ENERGY_RESET: self.config_entry.options.get(
+                    ConfName.ALLOW_BATTERY_ENERGY_RESET,
+                    ConfDefaultFlag.ALLOW_BATTERY_ENERGY_RESET,
                 ),
             }
 
@@ -192,28 +168,28 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
                         default=user_input[CONF_SCAN_INTERVAL],
                     ): vol.Coerce(int),
                     vol.Optional(
-                        CONF_SINGLE_DEVICE_ENTITY,
-                        default=user_input[CONF_SINGLE_DEVICE_ENTITY],
+                        ConfName.SINGLE_DEVICE_ENTITY,
+                        default=user_input[ConfName.SINGLE_DEVICE_ENTITY],
                     ): cv.boolean,
                     vol.Optional(
-                        CONF_KEEP_MODBUS_OPEN,
-                        default=user_input[CONF_KEEP_MODBUS_OPEN],
+                        ConfName.KEEP_MODBUS_OPEN,
+                        default=user_input[ConfName.KEEP_MODBUS_OPEN],
                     ): cv.boolean,
                     vol.Optional(
-                        CONF_DETECT_METERS,
-                        default=user_input[CONF_DETECT_METERS],
+                        ConfName.DETECT_METERS,
+                        default=user_input[ConfName.DETECT_METERS],
                     ): cv.boolean,
                     vol.Optional(
-                        CONF_DETECT_BATTERIES,
-                        default=user_input[CONF_DETECT_BATTERIES],
+                        ConfName.DETECT_BATTERIES,
+                        default=user_input[ConfName.DETECT_BATTERIES],
                     ): cv.boolean,
                     vol.Optional(
-                        CONF_ADV_PWR_CONTROL,
-                        default=user_input[CONF_ADV_PWR_CONTROL],
+                        ConfName.ADV_PWR_CONTROL,
+                        default=user_input[ConfName.ADV_PWR_CONTROL],
                     ): cv.boolean,
                     vol.Optional(
-                        CONF_ALLOW_BATTERY_ENERGY_RESET,
-                        default=user_input[CONF_ALLOW_BATTERY_ENERGY_RESET],
+                        ConfName.ALLOW_BATTERY_ENERGY_RESET,
+                        default=user_input[ConfName.ALLOW_BATTERY_ENERGY_RESET],
                     ): cv.boolean,
                 },
             ),
@@ -231,11 +207,12 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
 
         else:
             user_input = {
-                CONF_ADV_STORAGE_CONTROL: self.config_entry.options.get(
-                    CONF_ADV_STORAGE_CONTROL, DEFAULT_ADV_STORAGE_CONTROL
+                ConfName.ADV_STORAGE_CONTROL: self.config_entry.options.get(
+                    ConfName.ADV_STORAGE_CONTROL, ConfDefaultFlag.ADV_STORAGE_CONTROL
                 ),
-                CONF_ADV_SITE_LIMIT_CONTROL: self.config_entry.options.get(
-                    CONF_ADV_SITE_LIMIT_CONTROL, DEFAULT_ADV_SITE_LIMIT_CONTROL
+                ConfName.ADV_SITE_LIMIT_CONTROL: self.config_entry.options.get(
+                    ConfName.ADV_SITE_LIMIT_CONTROL,
+                    ConfDefaultFlag.ADV_SITE_LIMIT_CONTROL,
                 ),
             }
 
@@ -244,12 +221,12 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_ADV_STORAGE_CONTROL,
-                        default=user_input[CONF_ADV_STORAGE_CONTROL],
+                        ConfName.ADV_STORAGE_CONTROL,
+                        default=user_input[ConfName.ADV_STORAGE_CONTROL],
                     ): cv.boolean,
                     vol.Required(
-                        CONF_ADV_SITE_LIMIT_CONTROL,
-                        default=user_input[CONF_ADV_SITE_LIMIT_CONTROL],
+                        ConfName.ADV_SITE_LIMIT_CONTROL,
+                        default=user_input[ConfName.ADV_SITE_LIMIT_CONTROL],
                     ): cv.boolean,
                 }
             ),

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -28,8 +28,8 @@ class ConfDefaultInt(IntEnum):
 class ConfDefaultFlag(Flag):
     DETECT_METERS = True
     DETECT_BATTERIES = False
-    SINGLE_DEVICE_ENTITY = True
     KEEP_MODBUS_OPEN = False
+    SINGLE_DEVICE_ENTITY = True
     ADV_PWR_CONTROL = False
     ADV_STORAGE_CONTROL = False
     ADV_SITE_LIMIT_CONTROL = False
@@ -37,15 +37,15 @@ class ConfDefaultFlag(Flag):
 
 
 class ConfName(StrEnum):
-    ADV_PWR_CONTROL = "advanced_power_control"
-    ADV_STORAGE_CONTROL = "adv_storage_control"
-    ADV_SITE_LIMIT_CONTROL = "adv_site_limit_control"
     NUMBER_INVERTERS = "number_of_inverters"
     DEVICE_ID = "device_id"
     DETECT_METERS = "detect_meters"
     DETECT_BATTERIES = "detect_batteries"
     SINGLE_DEVICE_ENTITY = "single_device_entity"
     KEEP_MODBUS_OPEN = "keep_modbus_open"
+    ADV_PWR_CONTROL = "advanced_power_control"
+    ADV_STORAGE_CONTROL = "adv_storage_control"
+    ADV_SITE_LIMIT_CONTROL = "adv_site_limit_control"
     ALLOW_BATTERY_ENERGY_RESET = "allow_battery_energy_reset"
 
 

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -1,4 +1,4 @@
-from enum import IntEnum
+from enum import Flag, IntEnum, StrEnum
 from typing import Final
 
 DOMAIN = "solaredge_modbus_multi"
@@ -31,12 +31,44 @@ ENERGY_VOLT_AMPERE_HOUR: Final = "VAh"
 ENERGY_VOLT_AMPERE_REACTIVE_HOUR: Final = "varh"
 
 
-class SunSpecNotImpl(IntEnum):
-    INT16 = 0x8000
-    UINT16 = 0xFFFF
-    INT32 = 0x80000000
-    UINT32 = 0xFFFFFFFF
-    FLOAT32 = 0x7FC00000
+class BatteryLimit(IntEnum):
+    Vmin = 0
+    Vmax = 600
+    Amin = -200
+    Amax = 200
+    Tmax = 100
+    Tmin = -30
+
+
+class ConfDefaultInt(IntEnum):
+    SCAN_INTERVAL = 300
+    PORT = 1502
+    NUMBER_INVERTERS = 1
+    DEVICE_ID = 1
+
+
+class ConfDefaultFlag(Flag):
+    DETECT_METERS = True
+    DETECT_BATTERIES = False
+    SINGLE_DEVICE_ENTITY = True
+    KEEP_MODBUS_OPEN = False
+    ADV_PWR_CONTROL = False
+    ADV_STORAGE_CONTROL = False
+    ADV_SITE_LIMIT_CONTROL = False
+    ALLOW_BATTERY_ENERGY_RESET = False
+
+
+class ConfName(StrEnum):
+    ADV_PWR_CONTROL = "advanced_power_control"
+    ADV_STORAGE_CONTROL = "adv_storage_control"
+    ADV_SITE_LIMIT_CONTROL = "adv_site_limit_control"
+    NUMBER_INVERTERS = "number_of_inverters"
+    DEVICE_ID = "device_id"
+    DETECT_METERS = "detect_meters"
+    DETECT_BATTERIES = "detect_batteries"
+    SINGLE_DEVICE_ENTITY = "single_device_entity"
+    KEEP_MODBUS_OPEN = "keep_modbus_open"
+    ALLOW_BATTERY_ENERGY_RESET = "allow_battery_energy_reset"
 
 
 class SunSpecAccum(IntEnum):
@@ -46,13 +78,12 @@ class SunSpecAccum(IntEnum):
     LIMIT32 = 0xFFFFFFFF
 
 
-class BatteryLimit(IntEnum):
-    Vmin = 0
-    Vmax = 600
-    Amin = -200
-    Amax = 200
-    Tmax = 100
-    Tmin = -30
+class SunSpecNotImpl(IntEnum):
+    INT16 = 0x8000
+    UINT16 = 0xFFFF
+    INT32 = 0x80000000
+    UINT32 = 0xFFFFFFFF
+    FLOAT32 = 0x7FC00000
 
 
 SUNSPEC_SF_RANGE = [

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -1,5 +1,7 @@
-from enum import Flag, IntEnum, StrEnum
+from enum import Flag, IntEnum
 from typing import Final
+
+from homeassistant.backports.enum import StrEnum
 
 DOMAIN = "solaredge_modbus_multi"
 DEFAULT_NAME = "SolarEdge"

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -3,28 +3,6 @@ from typing import Final
 
 DOMAIN = "solaredge_modbus_multi"
 DEFAULT_NAME = "SolarEdge"
-DEFAULT_SCAN_INTERVAL = 300
-DEFAULT_PORT = 1502
-DEFAULT_NUMBER_INVERTERS = 1
-DEFAULT_DEVICE_ID = 1
-DEFAULT_DETECT_METERS = True
-DEFAULT_DETECT_BATTERIES = False
-DEFAULT_SINGLE_DEVICE_ENTITY = True
-DEFAULT_KEEP_MODBUS_OPEN = False
-DEFAULT_ADV_PWR_CONTROL = False
-DEFAULT_ADV_STORAGE_CONTROL = False
-DEFAULT_ADV_SITE_LIMIT_CONTROL = False
-DEFAULT_ALLOW_BATTERY_ENERGY_RESET = False
-CONF_ADV_PWR_CONTROL = "advanced_power_control"
-CONF_ADV_STORAGE_CONTROL = "adv_storage_control"
-CONF_ADV_SITE_LIMIT_CONTROL = "adv_site_limit_control"
-CONF_NUMBER_INVERTERS = "number_of_inverters"
-CONF_DEVICE_ID = "device_id"
-CONF_DETECT_METERS = "detect_meters"
-CONF_DETECT_BATTERIES = "detect_batteries"
-CONF_SINGLE_DEVICE_ENTITY = "single_device_entity"
-CONF_KEEP_MODBUS_OPEN = "keep_modbus_open"
-CONF_ALLOW_BATTERY_ENERGY_RESET = "allow_battery_energy_reset"
 
 # units missing in homeassistant core
 ENERGY_VOLT_AMPERE_HOUR: Final = "VAh"


### PR DESCRIPTION
List of constants to import for config was getting too long. Using enums makes the imports shorter.