### PR TITLE
Add inverter command delay option

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -68,6 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ConfName.ALLOW_BATTERY_ENERGY_RESET,
             ConfDefaultFlag.ALLOW_BATTERY_ENERGY_RESET,
         ),
+        entry.options.get(ConfName.SLEEP_AFTER_WRITE, ConfDefaultInt.SLEEP_AFTER_WRITE),
     )
 
     coordinator = SolarEdgeCoordinator(

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -201,9 +201,14 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
         errors = {}
 
         if user_input is not None:
-            return self.async_create_entry(
-                title="", data={**self.init_info, **user_input}
-            )
+            if user_input[ConfName.SLEEP_AFTER_WRITE] < 0:
+                errors[ConfName.SLEEP_AFTER_WRITE] = "invalid_sleep_interval"
+            elif user_input[ConfName.SLEEP_AFTER_WRITE] > 10:
+                errors[ConfName.SLEEP_AFTER_WRITE] = "invalid_sleep_interval"
+            else:
+                return self.async_create_entry(
+                    title="", data={**self.init_info, **user_input}
+                )
 
         else:
             user_input = {
@@ -213,6 +218,9 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
                 ConfName.ADV_SITE_LIMIT_CONTROL: self.config_entry.options.get(
                     ConfName.ADV_SITE_LIMIT_CONTROL,
                     ConfDefaultFlag.ADV_SITE_LIMIT_CONTROL,
+                ),
+                ConfName.SLEEP_AFTER_WRITE: self.config_entry.options.get(
+                    ConfName.SLEEP_AFTER_WRITE, ConfDefaultInt.SLEEP_AFTER_WRITE
                 ),
             }
 
@@ -228,6 +236,10 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
                         f"{ConfName.ADV_SITE_LIMIT_CONTROL}",
                         default=user_input[ConfName.ADV_SITE_LIMIT_CONTROL],
                     ): cv.boolean,
+                    vol.Optional(
+                        f"{ConfName.SLEEP_AFTER_WRITE}",
+                        default=user_input[ConfName.SLEEP_AFTER_WRITE],
+                    ): vol.Coerce(int),
                 }
             ),
             errors=errors,

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -25,6 +25,7 @@ class ConfDefaultInt(IntEnum):
     PORT = 1502
     NUMBER_INVERTERS = 1
     DEVICE_ID = 1
+    SLEEP_AFTER_WRITE = 3
 
 
 class ConfDefaultFlag(Flag):
@@ -49,6 +50,7 @@ class ConfName(StrEnum):
     ADV_STORAGE_CONTROL = "adv_storage_control"
     ADV_SITE_LIMIT_CONTROL = "adv_site_limit_control"
     ALLOW_BATTERY_ENERGY_RESET = "allow_battery_energy_reset"
+    SLEEP_AFTER_WRITE = "sleep_after_write"
 
 
 class SunSpecAccum(IntEnum):

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import threading
 from collections import OrderedDict
@@ -496,6 +497,10 @@ class SolarEdgeModbusMultiHub:
 
                 else:
                     raise ModbusWriteError(result)
+
+        if self._sleep_after_write > 0:
+            _LOGGER.debug(f"Sleeping {self._sleep_after_write} seconds after write.")
+            await asyncio.sleep(self._sleep_after_write)
 
 
 class SolarEdgeInverter:

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -75,6 +75,7 @@ class SolarEdgeModbusMultiHub:
         adv_storage_control: bool = False,
         adv_site_limit_control: bool = False,
         allow_battery_energy_reset: bool = False,
+        sleep_after_write: int = 3,
     ):
         """Initialize the Modbus hub."""
         self._hass = hass
@@ -91,6 +92,7 @@ class SolarEdgeModbusMultiHub:
         self._adv_storage_control = adv_storage_control
         self._adv_site_limit_control = adv_site_limit_control
         self._allow_battery_energy_reset = allow_battery_energy_reset
+        self._sleep_after_write = sleep_after_write
         self._lock = threading.Lock()
         self._id = name.lower()
         self._coordinator_timeout = 30
@@ -123,6 +125,7 @@ class SolarEdgeModbusMultiHub:
                 f"adv_storage_control={self._adv_storage_control}, "
                 f"adv_site_limit_control={self._adv_site_limit_control}, "
                 f"allow_battery_energy_reset={self._allow_battery_energy_reset}, "
+                f"sleep_after_write={self._sleep_after_write}, "
             ),
         )
 

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -44,13 +44,15 @@
         "title": "Power Control Options",
         "data": {
           "adv_storage_control": "Enable Storage Control",
-          "adv_site_limit_control": "Enable Site Limit Control"   
+          "adv_site_limit_control": "Enable Site Limit Control",
+          "sleep_after_write": "Command Delay (seconds)"
         },
         "description": "Warning: These options can violate utility agreements, alter your utility billing, may require special equipment, and overwrite provisioning by SolarEdge or your installer. Use at your own risk!"
       }
     },
     "error": {
-      "invalid_scan_interval": "Valid interval is 1 to 86400 seconds."
+      "invalid_scan_interval": "Valid interval is 1 to 86400 seconds.",
+      "invalid_sleep_interval": "Valid interval is 0 to 10 seconds."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -44,13 +44,15 @@
         "title": "Energiesteuerungsoptionen",
         "data": {
           "adv_storage_control": "Speichersteuerung aktivieren",
-          "adv_site_limit_control": "Site-Limit-Kontrolle aktivieren"   
+          "adv_site_limit_control": "Site-Limit-Kontrolle aktivieren",
+          "sleep_after_write": "Befehlsverzögerung des Wechselrichters (Sekunden)"
         },
         "description": "Warnung: Diese Optionen können gegen Stromverträge verstoßen, Ihre Stromabrechnung ändern, möglicherweise spezielle Geräte erfordern und die Bereitstellung durch SolarEdge oder Ihren Installateur überschreiben. Benutzung auf eigene Gefahr!"
       }
     },
     "error": {
-      "invalid_scan_interval": "Gültiges Intervall ist 1 bis 86400 Sekunden."
+      "invalid_scan_interval": "Gültiges Intervall ist 1 bis 86400 Sekunden.",
+      "invalid_sleep_interval": "Gültiges Intervall ist 0 bis 10 Sekunden."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -44,13 +44,15 @@
         "title": "Power Control Options",
         "data": {
           "adv_storage_control": "Enable Storage Control",
-          "adv_site_limit_control": "Enable Site Limit Control"   
+          "adv_site_limit_control": "Enable Site Limit Control",
+          "sleep_after_write": "Inverter Command Delay (seconds)"
         },
         "description": "Warning: These options can violate utility agreements, alter your utility billing, may require special equipment, and overwrite provisioning by SolarEdge or your installer. Use at your own risk!"
       }
     },
     "error": {
-      "invalid_scan_interval": "Valid interval is 1 to 86400 seconds."
+      "invalid_scan_interval": "Valid interval is 1 to 86400 seconds.",
+      "invalid_sleep_interval": "Valid interval is 0 to 10 seconds."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -44,13 +44,15 @@
         "title": "Strømkontrollalternativer",
         "data": {
           "adv_storage_control": "Aktiver lagringskontroll",
-          "adv_site_limit_control": "Aktiver Site Limit Control"   
+          "adv_site_limit_control": "Aktiver Site Limit Control",
+          "sleep_after_write": "Inverter Command Delay (sekunder)"
         },
         "description": "Advarsel: Disse alternativene kan bryte forsyningsavtaler, endre forbruksfaktureringen, kan kreve spesialutstyr og overskrive klargjøring av SolarEdge eller installatøren. Bruk på eget ansvar!"
       }
     },
     "error": {
-      "invalid_scan_interval": "Gyldig intervall er 1 til 86400 sekunder."
+      "invalid_scan_interval": "Gyldig intervall er 1 til 86400 sekunder.",
+      "invalid_sleep_interval": "Gyldig intervall er 0 til 10 sekunder."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -44,13 +44,15 @@
         "title": "Opties voor stroomregeling",
         "data": {
           "adv_storage_control": "Opslagbeheer inschakelen",
-          "adv_site_limit_control": "Beheer van sitelimiet inschakelen"   
+          "adv_site_limit_control": "Beheer van sitelimiet inschakelen",
+          "sleep_after_write": "Omvormer commando vertraging (seconden)"
         },
         "description": "Waarschuwing: deze opties kunnen in strijd zijn met nutsvoorzieningen, de facturering van uw nutsbedrijf wijzigen, mogelijk speciale apparatuur vereisen en de voorzieningen door SolarEdge of uw installateur overschrijven. Gebruik op eigen risico!"
       }
     },
     "error": {
-      "invalid_scan_interval": "Geldig interval is 1 tot 86400 seconden."
+      "invalid_scan_interval": "Geldig interval is 1 tot 86400 seconden.",
+      "invalid_sleep_interval": "Geldig interval is 0 tot 10 seconden."
     }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -44,13 +44,15 @@
         "title": "Opcje sterowania zasilaniem",
         "data": {
           "adv_storage_control": "Włącz kontrolę pamięci",
-          "adv_site_limit_control": "Włącz kontrolę limitu witryny"   
+          "adv_site_limit_control": "Włącz kontrolę limitu witryny",
+          "sleep_after_write": "Opóźnienie polecenia falownika (sekundy)"
         },
         "description": "Ostrzeżenie: opcje te mogą naruszać umowy za media, zmieniać rozliczenia za media, mogą wymagać specjalnego sprzętu i nadpisać udostępnianie przez SolarEdge lub instalatora. Używaj na własne ryzyko!"
       }
     },
     "error": {
-      "invalid_scan_interval": "Próbkowanie musi być w zakresie od 1 do 86400 sekund."
+      "invalid_scan_interval": "Próbkowanie musi być w zakresie od 1 do 86400 sekund.",
+      "invalid_sleep_interval": "Próbkowanie musi być w zakresie od 0 do 10 sekund."
     }
   }
 }


### PR DESCRIPTION
Add inverter command delay option which delays further requests after an inverter command is sent to allow the inverter time to execute the command. Valid range is 0 to 10 seconds, where 0 disables the delay. Default is 3 seconds.