### PR TITLE
Allow command delay up to 60 seconds

### DIFF
--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -203,7 +203,7 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             if user_input[ConfName.SLEEP_AFTER_WRITE] < 0:
                 errors[ConfName.SLEEP_AFTER_WRITE] = "invalid_sleep_interval"
-            elif user_input[ConfName.SLEEP_AFTER_WRITE] > 10:
+            elif user_input[ConfName.SLEEP_AFTER_WRITE] > 60:
                 errors[ConfName.SLEEP_AFTER_WRITE] = "invalid_sleep_interval"
             else:
                 return self.async_create_entry(


### PR DESCRIPTION
Probably harmless to allow a long command delay since it's up to the user to choose the best value for their setup.