### PR TITLE
Error message for missing or unsupported pymodbus

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -5,11 +5,17 @@ from collections import OrderedDict
 from typing import Any, Dict, Optional
 
 from homeassistant.core import HomeAssistant
-from pymodbus.client import ModbusTcpClient
-from pymodbus.constants import Endian
-from pymodbus.exceptions import ConnectionException, ModbusIOException
-from pymodbus.payload import BinaryPayloadDecoder
-from pymodbus.pdu import ExceptionResponse, ModbusExceptions
+
+try:
+    from pymodbus.client import ModbusTcpClient
+    from pymodbus.constants import Endian
+    from pymodbus.exceptions import ConnectionException, ModbusIOException
+    from pymodbus.payload import BinaryPayloadDecoder
+    from pymodbus.pdu import ExceptionResponse, ModbusExceptions
+except ImportError:
+    raise ImportError(
+        "pymodbus is not installed, or pymodbus version is not supported"
+    )
 
 from .const import DOMAIN, SunSpecNotImpl
 from .helpers import float_to_hex, parse_modbus_string

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -13,9 +13,7 @@ try:
     from pymodbus.payload import BinaryPayloadDecoder
     from pymodbus.pdu import ExceptionResponse, ModbusExceptions
 except ImportError:
-    raise ImportError(
-        "pymodbus is not installed, or pymodbus version is not supported"
-    )
+    raise ImportError("pymodbus is not installed, or pymodbus version is not supported")
 
 from .const import DOMAIN, SunSpecNotImpl
 from .helpers import float_to_hex, parse_modbus_string


### PR DESCRIPTION
Clearly log an error message when pymodbus is missing or unsupported.