### PR TITLE
Tweaks for Battery Validation and Status

### DIFF
--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -19,7 +19,7 @@ else:
 DOMAIN = "solaredge_modbus_multi"
 DEFAULT_NAME = "SolarEdge"
 # Factor to allow above rated capacity and still consider valid.
-BATTERY_RATE_ADJUSTMENT: Final = 1.03
+BATTERY_RATED_ADJUSTMENT: Final = 1.03
 # units missing in homeassistant core
 ENERGY_VOLT_AMPERE_HOUR: Final = "VAh"
 ENERGY_VOLT_AMPERE_REACTIVE_HOUR: Final = "varh"

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -19,7 +19,7 @@ else:
 DOMAIN = "solaredge_modbus_multi"
 DEFAULT_NAME = "SolarEdge"
 # Factor to allow above rated capacity and still consider valid.
-BATTERY_RATED_ADJUSTMENT: Final = 1.03
+BATTERY_RATED_ADJUSTMENT: Final = 1.06
 # units missing in homeassistant core
 ENERGY_VOLT_AMPERE_HOUR: Final = "VAh"
 ENERGY_VOLT_AMPERE_REACTIVE_HOUR: Final = "varh"

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -224,7 +224,7 @@ BATTERY_STATUS = {
     3: "Charge",
     4: "Discharge",
     5: "Fault",
-    6: "Preserve Charge", # This is largely undocumented, so may only apply to SE EnergyBank - when command is charge but battery is already fully charged. 
+    6: "Preserve Charge",
     7: "Idle",
     10: "Power Saving",
 }

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -18,7 +18,8 @@ else:
 
 DOMAIN = "solaredge_modbus_multi"
 DEFAULT_NAME = "SolarEdge"
-
+# Factor to allow above rated capacity and still consider valid.
+BATTERY_RATE_ADJUSTMENT: Final = 1.03
 # units missing in homeassistant core
 ENERGY_VOLT_AMPERE_HOUR: Final = "VAh"
 ENERGY_VOLT_AMPERE_REACTIVE_HOUR: Final = "varh"
@@ -223,6 +224,7 @@ BATTERY_STATUS = {
     3: "Charge",
     4: "Discharge",
     5: "Fault",
+    6: "Preserve Charge", # This is largely undocumented, so may only apply to SE EnergyBank - when command is charge but battery is already fully charged. 
     7: "Idle",
     10: "Power Saving",
 }

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -24,8 +24,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
-    BATTERY_STATUS,
     BATTERY_RATED_ADJUSTMENT,
+    BATTERY_STATUS,
     DEVICE_STATUS,
     DEVICE_STATUS_DESC,
     DOMAIN,

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     BATTERY_STATUS,
+    BATTERY_RATED_ADJUSTMENT,
     DEVICE_STATUS,
     DEVICE_STATUS_DESC,
     DOMAIN,
@@ -2085,7 +2086,7 @@ class SolarEdgeBatteryAvailableEnergy(SolarEdgeSensorBase):
             == hex(SunSpecNotImpl.FLOAT32)
             or self._platform.decoded_model["B_Energy_Available"] < 0
             or self._platform.decoded_model["B_Energy_Available"]
-            > self._platform.decoded_common["B_RatedEnergy"] * 1.03
+            > self._platform.decoded_common["B_RatedEnergy"] * BATTERY_RATED_ADJUSTMENT
         ):
             return None
 

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -2085,7 +2085,7 @@ class SolarEdgeBatteryAvailableEnergy(SolarEdgeSensorBase):
             == hex(SunSpecNotImpl.FLOAT32)
             or self._platform.decoded_model["B_Energy_Available"] < 0
             or self._platform.decoded_model["B_Energy_Available"]
-            > self._platform.decoded_common["B_RatedEnergy"]
+            > self._platform.decoded_common["B_RatedEnergy"] * 1.03
         ):
             return None
 


### PR DESCRIPTION
I am not a python dev so be gentle ;) 

I'd already noticed a couple of discussions on this topic, but I have been running this tweak and it seems to fix it, from what I can gather on previous versions of the EnergyBank you end up in a situation where the available energy dips well below the rated - I opened a support ticket and they bumped firmware and config which immediately caused SoH to jump, but as a consequence a full charge now is slightly higher than the rated capacity. 

For a brand new battery this isn't entirely unexpected, but obviously causes the validation to fail - adding a 3% fudge factor seems to work for me and I would expect beyond 3% to be a problem with the BMS not a real value - but its a finger in the air figure. 

Also added is the completely undocumented status 6 for battery - I only have a EnergyBank to test with but this is a preserve hold state that is distinct from power saving, I am charging on a ToU tariff so I see it daily when the battery is fully charged but command mode is still charge from grid. 

Appreciate its a bit of guess work so if you don't want to take the PR thats fine, I am happy running my fork too :) and thanks for the work on the integration :chef-kiss: