### PR TITLE
Enable debug logging through UI

### DIFF
--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -9,5 +9,6 @@
   "config_flow": true,
   "iot_class": "local_polling",
   "integration_type": "hub",
-  "version": "v2.2.9"
+  "loggers": ["custom_components.solaredge_modbus_multi"],
+  "version": "v2.2.10-pre.1"
 }


### PR DESCRIPTION
Add loggers to manifest so you can enable/disable debug logging in the UI instead of having to edit a file.