### PR TITLE
HA core is getting pymodbus 3.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ After rebooting Home Assistant, this integration can be configured through the i
 [WillCodeForCats/solaredge-modbus-multi/wiki](https://github.com/WillCodeForCats/solaredge-modbus-multi/wiki)
 
 ### Required Versions
-* Home Assistant 2023.1.0 or newer
+* Home Assistant 2023.2.0 or newer
 * Python 3.10 or newer
-* pymodbus 3.0.2 or newer
+* pymodbus 3.1.1 or newer
 
 ## Specifications
 [WillCodeForCats/solaredge-modbus-multi/tree/main/doc](https://github.com/WillCodeForCats/solaredge-modbus-multi/tree/main/doc)

--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -3,7 +3,7 @@
   "name": "SolarEdge Modbus Multi Device",
   "documentation": "https://github.com/WillCodeForCats/solaredge-modbus-multi/wiki",
   "issue_tracker": "https://github.com/WillCodeForCats/solaredge-modbus-multi/issues",
-  "requirements": ["pymodbus>=3.0.2"],
+  "requirements": ["pymodbus>=3.1.1"],
   "dependencies": [],
   "codeowners": ["@WillCodeForCats"],
   "config_flow": true,

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "SolarEdge Modbus Multi Device",
   "content_in_root": false,
-  "homeassistant": "2023.1.0",
+  "homeassistant": "2023.2.0",
   "render_readme": false
 }

--- a/info.md
+++ b/info.md
@@ -23,4 +23,4 @@ Read more on the wiki: [WillCodeForCats/solaredge-modbus-multi/wiki](https://git
 * Supports status and error reporting sensors.
 * User friendly configuration through Config Flow.
 
-Requires Home Assistant 2023.1.0 and newer.
+Requires Home Assistant 2023.2.0 and newer.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymodbus>=3.0.2
+pymodbus>=3.1.1


### PR DESCRIPTION
HA core is getting pymodbus 3.1.1, change our requirements to pymodbus>=3.1.1

Merge after there's an HA release with it and update our min required HA version to match.