### PR TITLE
Fix device/state class incompatibility

### DIFF
--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -2030,7 +2030,6 @@ class SolarEdgeBatteryEnergyImport(SolarEdgeSensorBase):
 
 
 class SolarEdgeBatteryMaxEnergy(SolarEdgeSensorBase):
-    device_class = SensorDeviceClass.ENERGY
     state_class = SensorStateClass.MEASUREMENT
     native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
 
@@ -2062,7 +2061,6 @@ class SolarEdgeBatteryMaxEnergy(SolarEdgeSensorBase):
 
 
 class SolarEdgeBatteryAvailableEnergy(SolarEdgeSensorBase):
-    device_class = SensorDeviceClass.ENERGY
     state_class = SensorStateClass.MEASUREMENT
     native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
 


### PR DESCRIPTION
SensorDeviceClass.ENERGY can't be combined with SensorStateClass.MEASUREMENT as of HA 2023.2