### PR TITLE
Retry polling cycle updates

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -186,7 +186,6 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         try:
             async with async_timeout.timeout(self._hub.coordinator_timeout):
-                # return await self._hub.async_refresh_modbus_data()
                 return await self._refresh_modbus_data_with_retry(
                     DataUpdateFailed, 4, wait_ms=200
                 )

--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -204,7 +204,7 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
         wait_increase_ratio=2,
     ):
         """
-        Retry a function invocation until no exception occurs
+        Retry refresh until no exception occurs or retries exhaust
         :param ex_type: retry only if exception is subclass of this type
         :param limit: maximum number of invocation attempts
         :param wait_ms: initial wait time after each attempt in milliseconds.
@@ -224,11 +224,11 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
                     _LOGGER.debug("no more data refresh retry attempts")
                     raise ex
 
-                _LOGGER.debug("failed data refresh attempt #%d", attempt, exc_info=ex)
+                _LOGGER.debug(f"failed data refresh attempt #{attempt}", exc_info=ex)
 
                 attempt += 1
                 _LOGGER.debug(
-                    "waiting %d ms before data refresh attempt #%d", wait_ms, attempt
+                    f"waiting {wait_ms} ms before data refresh attempt #{attempt}"
                 )
                 await asyncio.sleep(wait_ms / 1000)
                 wait_ms *= wait_increase_ratio

--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -222,12 +222,14 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
                 if not isinstance(ex, ex_type):
                     raise ex
                 if 0 < limit <= attempt:
-                    _LOGGER.warning("no more attempts")
+                    _LOGGER.debug("no more data refresh retry attempts")
                     raise ex
 
-                _LOGGER.error("failed execution attempt #%d", attempt, exc_info=ex)
+                _LOGGER.debug("failed data refresh attempt #%d", attempt, exc_info=ex)
 
                 attempt += 1
-                _LOGGER.debug("waiting %d ms before attempt #%d", wait_ms, attempt)
+                _LOGGER.debug(
+                    "waiting %d ms before data refresh attempt #%d", wait_ms, attempt
+                )
                 await asyncio.sleep(wait_ms / 1000)
                 wait_ms *= wait_increase_ratio

--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -189,7 +189,7 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
                 return await self._refresh_modbus_data_with_retry(
                     ex_type=DataUpdateFailed,
                     limit=4,
-                    wait_ms=200,
+                    wait_ms=400,
                 )
 
         except HubInitFailed as e:

--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -1,4 +1,5 @@
 """The SolarEdge Modbus Integration."""
+import asyncio
 import logging
 from datetime import timedelta
 from typing import Any
@@ -185,10 +186,48 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         try:
             async with async_timeout.timeout(self._hub.coordinator_timeout):
-                return await self._hub.async_refresh_modbus_data()
+                # return await self._hub.async_refresh_modbus_data()
+                return await self._refresh_modbus_data_with_retry(
+                    DataUpdateFailed, 4, wait_ms=200
+                )
 
         except HubInitFailed as e:
             raise UpdateFailed(f"{e}")
 
         except DataUpdateFailed as e:
             raise UpdateFailed(f"{e}")
+
+    async def _refresh_modbus_data_with_retry(
+        self,
+        ex_type=Exception,
+        limit=0,
+        wait_ms=100,
+        wait_increase_ratio=2,
+    ):
+        """
+        Retry a function invocation until no exception occurs
+        :param ex_type: retry only if exception is subclass of this type
+        :param limit: maximum number of invocation attempts
+        :param wait_ms: initial wait time after each attempt in milliseconds.
+        :param wait_increase_ratio: increase wait by multiplying by this after each try.
+        :return: result of first successful invocation
+        :raises: last invocation exception if attempts exhausted
+                 or exception is not an instance of ex_type
+        """
+        attempt = 1
+        while True:
+            try:
+                return await self._hub.async_refresh_modbus_data()
+            except Exception as ex:
+                if not isinstance(ex, ex_type):
+                    raise ex
+                if 0 < limit <= attempt:
+                    _LOGGER.warning("no more attempts")
+                    raise ex
+
+                _LOGGER.error("failed execution attempt #%d", attempt, exc_info=ex)
+
+                attempt += 1
+                _LOGGER.debug("waiting %d ms before attempt #%d", wait_ms, attempt)
+                await asyncio.sleep(wait_ms / 1000)
+                wait_ms *= wait_increase_ratio

--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -187,7 +187,9 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
         try:
             async with async_timeout.timeout(self._hub.coordinator_timeout):
                 return await self._refresh_modbus_data_with_retry(
-                    DataUpdateFailed, 4, wait_ms=200
+                    ex_type=DataUpdateFailed,
+                    limit=4,
+                    wait_ms=200,
                 )
 
         except HubInitFailed as e:
@@ -221,14 +223,14 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
                 if not isinstance(ex, ex_type):
                     raise ex
                 if 0 < limit <= attempt:
-                    _LOGGER.debug("no more data refresh retry attempts")
+                    _LOGGER.debug(f"No more data refresh attempts (maximum {limit})")
                     raise ex
 
-                _LOGGER.debug(f"failed data refresh attempt #{attempt}", exc_info=ex)
+                _LOGGER.debug(f"Failed data refresh attempt #{attempt}", exc_info=ex)
 
                 attempt += 1
                 _LOGGER.debug(
-                    f"waiting {wait_ms} ms before data refresh attempt #{attempt}"
+                    f"Waiting {wait_ms} ms before data refresh attempt #{attempt}"
                 )
                 await asyncio.sleep(wait_ms / 1000)
                 wait_ms *= wait_increase_ratio


### PR DESCRIPTION
Add logic to retry a polling cycle updates if it initially fails. The idea is to try to avoid "unavailable" states when random inverter connection problems happen by retrying a few times before giving up and going unavailable.