### PR TITLE
New const for storage charge/discharge limit

### DIFF
--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -31,6 +31,8 @@ class BatteryLimit(IntEnum):
     Amax = 200
     Tmax = 100
     Tmin = -30
+    ChargeMax = 50000
+    DischargeMax = 50000
 
 
 class ConfDefaultInt(IntEnum):

--- a/custom_components/solaredge_modbus_multi/number.py
+++ b/custom_components/solaredge_modbus_multi/number.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadBuilder
 
-from .const import DOMAIN, SunSpecNotImpl
+from .const import DOMAIN, BatteryLimit, SunSpecNotImpl
 from .helpers import float_to_hex
 
 _LOGGER = logging.getLogger(__name__)
@@ -282,7 +282,7 @@ class StorageChargeLimit(SolarEdgeNumberBase):
 
     @property
     def native_max_value(self) -> float:
-        return self._battery.decoded_common["B_MaxChargePower"]
+        return BatteryLimit.ChargeMax
 
     @property
     def native_value(self) -> float | None:
@@ -334,7 +334,7 @@ class StorageDischargeLimit(SolarEdgeNumberBase):
 
     @property
     def native_max_value(self) -> float:
-        return self._battery.decoded_common["B_MaxDischargePower"]
+        return BatteryLimit.DischargeMax
 
     @property
     def native_value(self) -> float | None:


### PR DESCRIPTION
Remove max value for storage charge/discharge setting and use a fixed value instead.

SolarEdge modbus only supports two batteries, making systems with a third battery invisible to the integration. The integration can't know a third battery exists or calculate what a third battery means to charge/discharge limits.