### PR TITLE
Add inverter capability flags to diagnostics

### DIFF
--- a/custom_components/solaredge_modbus_multi/diagnostics.py
+++ b/custom_components/solaredge_modbus_multi/diagnostics.py
@@ -43,6 +43,9 @@ async def async_get_config_entry_diagnostics(
         inverter: dict[str, Any] = {
             f"inverter_unit_id_{inverter.inverter_unit_id}": {
                 "device_info": inverter.device_info,
+                "global_power_control": inverter.global_power_control,
+                "advanced_power_control": inverter.advanced_power_control,
+                "site_limit_control": inverter.site_limit_control,
                 "common": inverter.decoded_common,
                 "model": format_values(inverter.decoded_model),
                 "is_mmppt": inverter.is_mmppt,

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -517,7 +517,7 @@ class SolarEdgeInverter:
         self.has_parent = False
         self.global_power_control = None
         self.advanced_power_control = None
-        self._has_site_limit_control = None
+        self.site_limit_control = None
 
     def init_device(self) -> None:
         inverter_data = self.hub.read_holding_registers(
@@ -950,7 +950,7 @@ class SolarEdgeInverter:
                 self.advanced_power_control = True
 
         """ Site Limit Control """
-        if self._has_site_limit_control is True or self._has_site_limit_control is None:
+        if self.site_limit_control is True or self.site_limit_control is None:
             inverter_data = self.hub.read_holding_registers(
                 unit=self.inverter_unit_id, address=57344, count=4
             )
@@ -964,7 +964,7 @@ class SolarEdgeInverter:
 
                 if type(inverter_data) is ExceptionResponse:
                     if inverter_data.exception_code == ModbusExceptions.IllegalAddress:
-                        self._has_site_limit_control = False
+                        self.site_limit_control = False
                         _LOGGER.debug(
                             (
                                 f"Inverter {self.inverter_unit_id}: "
@@ -972,11 +972,11 @@ class SolarEdgeInverter:
                             )
                         )
 
-                if self._has_site_limit_control is not False:
+                if self.site_limit_control is not False:
                     raise ModbusReadError(inverter_data)
 
             else:
-                self._has_site_limit_control = True
+                self.site_limit_control = True
 
                 decoder = BinaryPayloadDecoder.fromRegisters(
                     inverter_data.registers,
@@ -1020,7 +1020,7 @@ class SolarEdgeInverter:
                             )
                         )
 
-                if self._has_site_limit_control is not False:
+                if self.site_limit_control is not False:
                     raise ModbusReadError(inverter_data)
 
             else:


### PR DESCRIPTION
Add inverter capability flags to diagnostics to avoid having to go into debug mode to find out if the inverter reported these functions as available or not.