### PR TITLE
Update availability property for limit controls

### DIFF
--- a/custom_components/solaredge_modbus_multi/select.py
+++ b/custom_components/solaredge_modbus_multi/select.py
@@ -262,6 +262,13 @@ class SolaredgeLimitControlMode(SolarEdgeSelectBase):
         self._attr_options = list(self._options.values())
 
     @property
+    def available(self) -> bool:
+        return (
+            super().available
+            and "E_Lim_Ctl_Mode" in self._platform.decoded_model.keys()
+        )
+
+    @property
     def unique_id(self) -> str:
         return f"{self._platform.uid_base}_limit_control_mode"
 
@@ -311,6 +318,10 @@ class SolaredgeLimitControl(SolarEdgeSelectBase):
         super().__init__(platform, config_entry, coordinator)
         self._options = LIMIT_CONTROL
         self._attr_options = list(self._options.values())
+
+    @property
+    def available(self) -> bool:
+        return super().available and "E_Lim_Ctl" in self._platform.decoded_model.keys()
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/solaredge_modbus_multi/switch.py
+++ b/custom_components/solaredge_modbus_multi/switch.py
@@ -68,7 +68,20 @@ class SolarEdgeSwitchBase(CoordinatorEntity, SwitchEntity):
         self.async_write_ha_state()
 
 
-class SolarEdgeExternalProduction(SolarEdgeSwitchBase):
+class SolarEdgeELimitControlModeBase(SolarEdgeSwitchBase):
+    def __init__(self, platform, config_entry, coordinator):
+        super().__init__(platform, config_entry, coordinator)
+        """Initialize the sensor."""
+
+    @property
+    def available(self) -> bool:
+        return (
+            super().available
+            and "E_Lim_Ctl_Mode" in self._platform.decoded_model.keys()
+        )
+
+
+class SolarEdgeExternalProduction(SolarEdgeELimitControlModeBase):
     entity_category = EntityCategory.CONFIG
 
     def __init__(self, platform, config_entry, coordinator):
@@ -117,7 +130,7 @@ class SolarEdgeExternalProduction(SolarEdgeSwitchBase):
         await self.async_update()
 
 
-class SolarEdgeNegativeSiteLimit(SolarEdgeSwitchBase):
+class SolarEdgeNegativeSiteLimit(SolarEdgeELimitControlModeBase):
     entity_category = EntityCategory.CONFIG
 
     def __init__(self, platform, config_entry, coordinator):


### PR DESCRIPTION
Update availability property for limit controls since they were showing up in weird ways if limit control was enabled on inverters that don't support limit control over modbus.