### PR TITLE
Use DOMAIN_REGEX from voluptuous

### DIFF
--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -1,6 +1,7 @@
 """Constants used by SolarEdge Modbus Multi components."""
 from __future__ import annotations
 
+import re
 import sys
 from enum import IntEnum
 from typing import Final
@@ -25,6 +26,18 @@ DEFAULT_NAME = "SolarEdge"
 # units missing in homeassistant core
 ENERGY_VOLT_AMPERE_HOUR: Final = "VAh"
 ENERGY_VOLT_AMPERE_REACTIVE_HOUR: Final = "varh"
+
+# from voluptuous/validators.py
+DOMAIN_REGEX = re.compile(
+    # start anchor, because fullmatch is not available in python 2.7
+    "(?:"
+    # domain
+    r"(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+"
+    r"(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?$)"
+    # end anchor, because fullmatch is not available in python 2.7
+    r")\Z",
+    re.IGNORECASE,
+)
 
 
 class RetrySettings(IntEnum):

--- a/custom_components/solaredge_modbus_multi/helpers.py
+++ b/custom_components/solaredge_modbus_multi/helpers.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import ipaddress
-import re
 import struct
+
+from .const import DOMAIN_REGEX
 
 
 def scale_factor(value: int, sf: int):
@@ -43,6 +44,6 @@ def host_valid(host):
     try:
         if ipaddress.ip_address(host).version == (4 or 6):
             return True
+
     except ValueError:
-        disallowed = re.compile(r"[^a-zA-Z\d\-]")
-        return all(x and not disallowed.search(x) for x in host.split("."))
+        return DOMAIN_REGEX.match(host)


### PR DESCRIPTION
Use DOMAIN_REGEX for validating domain names from [voluptuous/validators.py](https://github.com/alecthomas/voluptuous/tree/master/voluptuous/validators.py), excluding SMTP literals.