### PR TITLE
Update battery energy reset options

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -80,6 +80,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.options.get(
             ConfName.BATTERY_RATING_ADJUST, ConfDefaultInt.BATTERY_RATING_ADJUST
         ),
+        entry.options.get(
+            ConfName.BATTERY_ENERGY_RESET_CYCLES,
+            bool(ConfDefaultInt.BATTERY_ENERGY_RESET_CYCLES),
+        ),
     )
 
     coordinator = SolarEdgeCoordinator(

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -198,6 +198,10 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
                     ConfName.ALLOW_BATTERY_ENERGY_RESET,
                     bool(ConfDefaultFlag.ALLOW_BATTERY_ENERGY_RESET),
                 ),
+                ConfName.BATTERY_ENERGY_RESET_CYCLES: self.config_entry.options.get(
+                    ConfName.BATTERY_ENERGY_RESET_CYCLES,
+                    ConfDefaultInt.BATTERY_ENERGY_RESET_CYCLES,
+                ),
                 ConfName.BATTERY_RATING_ADJUST: self.config_entry.options.get(
                     ConfName.BATTERY_RATING_ADJUST,
                     ConfDefaultInt.BATTERY_RATING_ADJUST,
@@ -212,6 +216,10 @@ class SolaredgeModbusMultiOptionsFlowHandler(config_entries.OptionsFlow):
                         f"{ConfName.ALLOW_BATTERY_ENERGY_RESET}",
                         default=user_input[ConfName.ALLOW_BATTERY_ENERGY_RESET],
                     ): cv.boolean,
+                    vol.Optional(
+                        f"{ConfName.BATTERY_ENERGY_RESET_CYCLES}",
+                        default=user_input[ConfName.BATTERY_ENERGY_RESET_CYCLES],
+                    ): vol.Coerce(int),
                     vol.Optional(
                         f"{ConfName.BATTERY_RATING_ADJUST}",
                         default=user_input[ConfName.BATTERY_RATING_ADJUST],

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -68,6 +68,7 @@ class ConfDefaultInt(IntEnum):
     DEVICE_ID = 1
     SLEEP_AFTER_WRITE = 3
     BATTERY_RATING_ADJUST = 0
+    BATTERY_ENERGY_RESET_CYCLES = 0
 
 
 class ConfDefaultFlag(IntEnum):
@@ -92,6 +93,7 @@ class ConfName(StrEnum):
     ALLOW_BATTERY_ENERGY_RESET = "allow_battery_energy_reset"
     SLEEP_AFTER_WRITE = "sleep_after_write"
     BATTERY_RATING_ADJUST = "battery_rating_adjust"
+    BATTERY_ENERGY_RESET_CYCLES = "battery_energy_reset_cycles"
 
 
 class SunSpecAccum(IntEnum):

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -109,6 +109,7 @@ class SolarEdgeModbusMultiHub:
         allow_battery_energy_reset: bool = False,
         sleep_after_write: int = 3,
         battery_rating_adjust: int = 0,
+        battery_energy_reset_cycles: int = 0,
     ):
         """Initialize the Modbus hub."""
         self._hass = hass
@@ -127,6 +128,7 @@ class SolarEdgeModbusMultiHub:
         self._allow_battery_energy_reset = allow_battery_energy_reset
         self._sleep_after_write = sleep_after_write
         self._battery_rating_adjust = battery_rating_adjust
+        self._battery_energy_reset_cycles = battery_energy_reset_cycles
         self._coordinator_timeout = 30
         self._client = None
         self._id = name.lower()
@@ -465,6 +467,10 @@ class SolarEdgeModbusMultiHub:
     @property
     def battery_rating_adjust(self) -> int:
         return (self._battery_rating_adjust + 100) / 100
+
+    @property
+    def battery_energy_reset_cycles(self) -> int:
+        return self._battery_energy_reset_cycles
 
     @keep_modbus_open.setter
     def keep_modbus_open(self, value: bool) -> None:

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1585,3 +1585,7 @@ class SolarEdgeBattery:
     @property
     def battery_rating_adjust(self) -> int:
         return self.hub.battery_rating_adjust
+
+    @property
+    def battery_energy_reset_cycles(self) -> int:
+        return self.hub.battery_energy_reset_cycles

--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/WillCodeForCats/solaredge-modbus-multi/issues",
   "loggers": ["custom_components.solaredge_modbus_multi"],
   "requirements": ["pymodbus>=3.1.1"],
-  "version": "2.3.4-pre.2"
+  "version": "2.3.4-pre.3"
 }

--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/WillCodeForCats/solaredge-modbus-multi/issues",
   "loggers": ["custom_components.solaredge_modbus_multi"],
   "requirements": ["pymodbus>=3.1.1"],
-  "version": "2.3.4-pre.3"
+  "version": "2.3.4-pre.2"
 }

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1824,11 +1824,7 @@ class SolarEdgeBatteryEnergyExport(SolarEdgeSensorBase):
                                 )
                             )
 
-                            if (
-                                self._platform.decoded_model["B_Export_Energy_WH"]
-                                == 0x0
-                            ):
-                                self._last = None
+                            self._last = None
 
                         return None
 
@@ -1850,6 +1846,7 @@ class SolarEdgeBatteryEnergyImport(SolarEdgeSensorBase):
         super().__init__(platform, config_entry, coordinator)
         """Initialize the sensor."""
         self._last = None
+        self._count = 0
 
     @property
     def unique_id(self) -> str:
@@ -1892,11 +1889,7 @@ class SolarEdgeBatteryEnergyImport(SolarEdgeSensorBase):
                                 )
                             ),
 
-                            if (
-                                self._platform.decoded_model["B_Import_Energy_WH"]
-                                == 0x0
-                            ):
-                                self._last = None
+                            self._last = None
 
                         return None
 

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1782,6 +1782,7 @@ class SolarEdgeBatteryEnergyExport(SolarEdgeSensorBase):
         super().__init__(platform, config_entry, coordinator)
         """Initialize the sensor."""
         self._last = None
+        self._count = 0
 
     @property
     def unique_id(self) -> str:
@@ -1824,7 +1825,11 @@ class SolarEdgeBatteryEnergyExport(SolarEdgeSensorBase):
                                 )
                             )
 
-                            self._last = None
+                            ++self._count
+
+                            if self._count > self._platform.battery_energy_reset_cycles:
+                                self._last = None
+                                self._count = 0
 
                         return None
 
@@ -1889,7 +1894,11 @@ class SolarEdgeBatteryEnergyImport(SolarEdgeSensorBase):
                                 )
                             ),
 
-                            self._last = None
+                            ++self._count
+
+                            if self._count > self._platform.battery_energy_reset_cycles:
+                                self._last = None
+                                self._count = 0
 
                         return None
 

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -51,6 +51,7 @@
         "title": "Battery Options",
         "data": {
           "allow_battery_energy_reset": "Allow Battery Energy to Reset",
+          "battery_energy_reset_cycles": "Update Cycles Before Battery Energy Reset",
           "battery_rating_adjust": "Battery Rating Adjustment (percent)"
         }
       }

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -51,7 +51,7 @@
         "title": "Battery Options",
         "data": {
           "allow_battery_energy_reset": "Allow Battery Energy to Reset",
-          "battery_energy_reset_cycles": "Update Cycles Before Battery Energy Reset",
+          "battery_energy_reset_cycles": "Update Cycles to Reset Battery Energy",
           "battery_rating_adjust": "Battery Rating Adjustment (percent)"
         }
       }

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -51,6 +51,7 @@
         "title": "Batterieoptionen",
         "data": {
           "allow_battery_energy_reset": "Batterieenergie zurücksetzen lassen",
+          "battery_energy_reset_cycles": "Aktualisierungszyklen zum Zurücksetzen der Batterieenergie",
           "battery_rating_adjust": "Anpassung der Batterieleistung (Prozent)"
         }
       }

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -51,6 +51,7 @@
         "title": "Battery Options",
         "data": {
           "allow_battery_energy_reset": "Allow Battery Energy to Reset",
+          "battery_energy_reset_cycles": "Update Cycles Before Battery Energy Reset",
           "battery_rating_adjust": "Battery Rating Adjustment (percent)"
         }
       }

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -51,7 +51,7 @@
         "title": "Battery Options",
         "data": {
           "allow_battery_energy_reset": "Allow Battery Energy to Reset",
-          "battery_energy_reset_cycles": "Update Cycles Before Battery Energy Reset",
+          "battery_energy_reset_cycles": "Update Cycles to Reset Battery Energy",
           "battery_rating_adjust": "Battery Rating Adjustment (percent)"
         }
       }

--- a/custom_components/solaredge_modbus_multi/translations/fr.json
+++ b/custom_components/solaredge_modbus_multi/translations/fr.json
@@ -51,6 +51,7 @@
         "title": "Options de batterie",
         "data": {
           "allow_battery_energy_reset": "Autoriser la réinitialisation de la batterie",
+          "battery_energy_reset_cycles": "Cycles de mise à jour pour réinitialiser l'énergie de la batterie",
           "battery_rating_adjust": "Ajustement de la capacité de la batterie (pourcentage)"
         }
       }

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -51,6 +51,7 @@
         "title": "Batterialternativer",
         "data": {
           "allow_battery_energy_reset": "La batterienergien tilbakestilles",
+          "battery_energy_reset_cycles": "Oppdater sykluser for å tilbakestille batterienergi",
           "battery_rating_adjust": "Justering av batterikapasitet (prosent)"
         }
       }

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -51,6 +51,7 @@
         "title": "Batterij opties",
         "data": {
           "allow_battery_energy_reset": "Batterij-energie laten resetten",
+          "battery_energy_reset_cycles": "Update cycli om de batterij-energie te resetten",
           "battery_rating_adjust": "Aanpassing batterijvermogen (%)"
         }
       }

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -51,6 +51,7 @@
         "title": "Opcje baterii",
         "data": {
           "allow_battery_energy_reset": "Zezwól na zresetowanie energii baterii",
+          "battery_energy_reset_cycles": "Zaktualizuj cykle, aby zresetować energię baterii",
           "battery_rating_adjust": "Regulacja oceny baterii (w procentach)"
         }
       }


### PR DESCRIPTION
* Remove zero condition to register value reset when allow battery energy reset option is enabled.
* Add new option to require N number of update cycles before battery energy resets (default 0)