### PR TITLE
Change batt VDC upper limit to 1000

### DIFF
--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -60,7 +60,7 @@ class BatteryLimit(IntEnum):
     """Configure battery limits for input and display validation."""
 
     Vmin = 0  # volts
-    Vmax = 600  # volts
+    Vmax = 1000  # volts
     Amin = -200  # amps
     Amax = 200  # amps
     Tmax = 100  # degrees C

--- a/doc/battery_specs.txt
+++ b/doc/battery_specs.txt
@@ -7,6 +7,10 @@ BYD Battery-Box Premium LVS 4.0, 8.0, 12.0, 16.0, 20.0, 24.0
 40-62 V DC
 130 A DC
 
+Note: in issue #370 a SolarEdge Home Battery with SE8K-RWS inverter reported battery
+voltages as high as 825 VDC when it's supposed to be a 48VDC nominal system.
+
+
 
 SE5000-XXS / SE6000-XXS
 LG Chem RESU7H


### PR DESCRIPTION
This PR changed the maximum display voltage for batteries up to 1000VDC, which as far as I'm aware will never actually occur with current hardware.

This change was made after it was reported that a 48VDC nominal system was reporting voltages above 800, although inaccurate (see issue #370).

Maybe it needs to be scaled by some multiplier or something, but the integration has no way to know that, and this allows for the possibility of using a template sensor to adjust it by comparing to an accurate voltage reading.