### PR TITLE
302 skip offline inverters when updating

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -179,6 +179,7 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=scan_interval),
         )
         self._hub = hub
+        self._count = 0
 
         if scan_interval < 10 and not self._hub.keep_modbus_open:
             _LOGGER.warning("Polling frequency < 10, requiring keep modbus open.")
@@ -186,6 +187,11 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         try:
+            if self._count > RetrySettings.Offline:
+                self._count = 0
+                self._hub.clear_offline_units()
+            self._count += 1
+
             return await self._refresh_modbus_data_with_retry(
                 ex_type=DataUpdateFailed,
                 limit=RetrySettings.Limit,

--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -185,14 +185,14 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
             _LOGGER.warning("Polling frequency < 10, requiring keep modbus open.")
             self._hub.keep_modbus_open = True
 
-    def next_time(self, minutes: int):
-        return datetime.now() + timedelta(minutes=minutes)
+    def next_time(self, milliseconds: int):
+        return datetime.now() + timedelta(milliseconds=milliseconds)
 
     async def _async_update_data(self):
         try:
             if datetime.now() > self._next_time:
                 self._next_time = self.next_time(RetrySettings.Offline)
-                self._hub.clear_offline_units()
+                self._hub.retry_offline_units()
 
             return await self._refresh_modbus_data_with_retry(
                 ex_type=DataUpdateFailed,

--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -222,14 +222,14 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
             try:
                 async with async_timeout.timeout(self._hub.coordinator_timeout):
                     return await self._hub.async_refresh_modbus_data()
-            except Exception as ex:
-                if not isinstance(ex, ex_type):
-                    raise ex
+            except Exception as e:
+                if not isinstance(e, ex_type):
+                    raise e
                 if 0 < limit <= attempt:
                     _LOGGER.debug(f"No more data refresh attempts (maximum {limit})")
-                    raise ex
+                    raise e
 
-                _LOGGER.debug(f"Failed data refresh attempt #{attempt}")
+                _LOGGER.debug(f"Failed data refresh attempt #{attempt}: {e}")
 
                 attempt += 1
                 _LOGGER.debug(

--- a/custom_components/solaredge_modbus_multi/button.py
+++ b/custom_components/solaredge_modbus_multi/button.py
@@ -27,6 +27,9 @@ async def async_setup_entry(
 
     for inverter in hub.inverters:
         entities.append(SolarEdgeRefreshButton(inverter, config_entry, coordinator))
+        entities.append(
+            SolarEdgeRetryOfflineUnitsButton(inverter, config_entry, coordinator)
+        )
 
     if entities:
         async_add_entities(entities)
@@ -79,4 +82,28 @@ class SolarEdgeRefreshButton(SolarEdgeButtonBase):
         return "Refresh"
 
     async def async_press(self) -> None:
+        await self.async_update()
+
+
+class SolarEdgeRetryOfflineUnitsButton(SolarEdgeButtonBase):
+    entity_category = EntityCategory.CONFIG
+
+    def __init__(self, platform, config_entry, coordinator):
+        super().__init__(platform, config_entry, coordinator)
+        """Initialize the sensor."""
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_retry_offline_units"
+
+    @property
+    def name(self) -> str:
+        return "Retry Offline Units"
+
+    @property
+    def available(self) -> bool:
+        return not super().available
+
+    async def async_press(self) -> None:
+        self._platform.clear_offline_units()
         await self.async_update()

--- a/custom_components/solaredge_modbus_multi/button.py
+++ b/custom_components/solaredge_modbus_multi/button.py
@@ -105,5 +105,5 @@ class SolarEdgeRetryOfflineUnitsButton(SolarEdgeButtonBase):
         return not super().available
 
     async def async_press(self) -> None:
-        self._platform.clear_offline_units()
+        self._platform.retry_offline_units()
         await self.async_update()

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -54,7 +54,7 @@ class RetrySettings(IntEnum):
     Time = 800  # first attempt in milliseconds
     Ratio = 3  # time multiplier between each attempt
     Limit = 4  # number of attempts before failing
-    Offline = 15  # Number of minutes to retry offline units
+    Offline = 5000  # time to retry offline units in milliseconds
 
 
 class BatteryLimit(IntEnum):

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -54,7 +54,7 @@ class RetrySettings(IntEnum):
     Time = 800  # first attempt in milliseconds
     Ratio = 3  # time multiplier between each attempt
     Limit = 4  # number of attempts before failing
-    Offline = 10  # Number of polling cycles to retry offline units
+    Offline = 15  # Number of minutes to retry offline units
 
 
 class BatteryLimit(IntEnum):

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -54,6 +54,7 @@ class RetrySettings(IntEnum):
     Time = 800  # first attempt in milliseconds
     Ratio = 3  # time multiplier between each attempt
     Limit = 4  # number of attempts before failing
+    Offline = 10  # Number of polling cycles to retry offline units
 
 
 class BatteryLimit(IntEnum):

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1495,6 +1495,8 @@ class SolarEdgeBattery:
         self.has_parent = True
         self.inverter_common = self.hub.inverter_common[self.inverter_unit_id]
 
+        self._online = True
+
         if self.battery_id == 1:
             self.start_address = 57600
         elif self.battery_id == 2:
@@ -1657,7 +1659,14 @@ class SolarEdgeBattery:
     @property
     def online(self) -> bool:
         """Device is online."""
-        return self.hub.online
+        return self.hub.online and self._online
+
+    @online.setter
+    def online(self, value: bool) -> None:
+        if value is True:
+            self._online = True
+        else:
+            self._online = False
 
     @property
     def inverter_unit_id(self) -> int:

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -445,7 +445,7 @@ class SolarEdgeModbusMultiHub:
                     if battery.inverter_unit_id in self.offline_units:
                         battery.online = False
                     else:
-                        meter.online = True
+                        battery.online = True
                         await battery.read_modbus_data()
 
             except ModbusReadError as e:

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1486,7 +1486,7 @@ class SolarEdgeBattery:
     def __init__(
         self, device_id: int, battery_id: int, hub: SolarEdgeModbusMultiHub
     ) -> None:
-        self.inverter_unit_id = device_id
+        self._inverter_unit_id = device_id
         self.hub = hub
         self.decoded_common = []
         self.decoded_model = []
@@ -1658,6 +1658,17 @@ class SolarEdgeBattery:
     def online(self) -> bool:
         """Device is online."""
         return self.hub.online
+
+    @property
+    def inverter_unit_id(self) -> int:
+        return self._inverter_unit_id
+
+    @inverter_unit_id.setter
+    def inverter_unit_id(self, value: int) -> None:
+        if value not in [1, 247]:
+            raise ValueError("Invalid inverter unit ID.")
+
+        self._inverter_unit_id = value
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -402,9 +402,27 @@ class SolarEdgeModbusMultiHub:
 
             try:
                 for inverter in self.inverters:
-                    await inverter.read_modbus_data()
+                    try:
+                        await inverter.read_modbus_data()
+                        if not inverter.online:
+                            _LOGGER.warning(
+                                f"Inverter ID {inverter.inverter_unit_id} ",
+                                "returned online.",
+                            )
+                            inverter.online = True
+
+                    except asyncio.TimeoutError as e:
+                        _LOGGER.debug(f"I{inverter.inverter_unit_id} timeout: {e}")
+                        if inverter.online:
+                            _LOGGER.warning(
+                                "Timeout while updating inverter ID "
+                                f"{inverter.inverter_unit_id}."
+                            )
+                            inverter.online = False
+
                 for meter in self.meters:
                     await meter.read_modbus_data()
+
                 for battery in self.batteries:
                     await battery.read_modbus_data()
 

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1241,7 +1241,7 @@ class SolarEdgeMeter:
     def __init__(
         self, device_id: int, meter_id: int, hub: SolarEdgeModbusMultiHub
     ) -> None:
-        self.inverter_unit_id = device_id
+        self._inverter_unit_id = device_id
         self.hub = hub
         self.decoded_common = []
         self.decoded_model = []
@@ -1457,6 +1457,17 @@ class SolarEdgeMeter:
     def online(self) -> bool:
         """Device is online."""
         return self.hub.online
+
+    @property
+    def inverter_unit_id(self) -> int:
+        return self._inverter_unit_id
+
+    @inverter_unit_id.setter
+    def inverter_unit_id(self, value: int) -> None:
+        if value not in [1, 247]:
+            raise ValueError("Invalid inverter unit ID.")
+
+        self._inverter_unit_id = value
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -431,7 +431,10 @@ class SolarEdgeModbusMultiHub:
                             inverter.online = True
 
                             _LOGGER.warning(
-                                f"Inverter ID {inverter.inverter_unit_id} recovered.",
+                                (
+                                    f"Inverter ID {inverter.inverter_unit_id} at "
+                                    f"{self.hub_host}:{self.hub_port} recovered."
+                                ),
                             )
 
                     except asyncio.TimeoutError as e:
@@ -441,7 +444,10 @@ class SolarEdgeModbusMultiHub:
                             inverter.online = False
 
                             _LOGGER.warning(
-                                f"Inverter ID {inverter.inverter_unit_id} went offline."
+                                (
+                                    f"Inverter ID {inverter.inverter_unit_id} at "
+                                    f"{self.hub_host}:{self.hub_port} went offline."
+                                ),
                             )
 
                         if inverter.inverter_unit_id not in self._offline_units:

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -657,7 +657,7 @@ class SolarEdgeModbusMultiHub:
 
 class SolarEdgeInverter:
     def __init__(self, device_id: int, hub: SolarEdgeModbusMultiHub) -> None:
-        self.inverter_unit_id = device_id
+        self._inverter_unit_id = device_id
         self.hub = hub
         self.decoded_common = []
         self.decoded_model = []
@@ -668,6 +668,8 @@ class SolarEdgeInverter:
         self.global_power_control = None
         self.advanced_power_control = None
         self.site_limit_control = None
+
+        self._online = True
 
     async def init_device(self) -> None:
         try:
@@ -1177,7 +1179,25 @@ class SolarEdgeInverter:
     @property
     def online(self) -> bool:
         """Device is online."""
-        return self.hub.online
+        return self.hub.online and self._online
+
+    @online.setter
+    def online(self, value: bool) -> None:
+        if value is True:
+            self._online = True
+        else:
+            self._online = False
+
+    @property
+    def inverter_unit_id(self) -> int:
+        return self._inverter_unit_id
+
+    @inverter_unit_id.setter
+    def inverter_unit_id(self, value: int) -> None:
+        if value not in [1, 247]:
+            raise ValueError("Invalid inverter unit ID.")
+
+        self._inverter_unit_id = value
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -414,6 +414,7 @@ class SolarEdgeModbusMultiHub:
                 for inverter in self.inverters:
                     try:
                         await inverter.read_modbus_data()
+
                         if not inverter.online:
                             _LOGGER.warning(
                                 f"Inverter ID {inverter.inverter_unit_id} ",
@@ -430,6 +431,7 @@ class SolarEdgeModbusMultiHub:
 
                     except asyncio.TimeoutError as e:
                         _LOGGER.debug(f"I{inverter.inverter_unit_id} timeout: {e}")
+
                         if inverter.online:
                             _LOGGER.warning(
                                 "Timeout while updating inverter ID "

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1234,7 +1234,7 @@ class SolarEdgeInverter:
 
     @inverter_unit_id.setter
     def inverter_unit_id(self, value: int) -> None:
-        if value not in [1, 247]:
+        if value not in range(1, 248):
             raise ValueError("Invalid inverter unit ID.")
 
         self._inverter_unit_id = value
@@ -1495,7 +1495,7 @@ class SolarEdgeMeter:
 
     @inverter_unit_id.setter
     def inverter_unit_id(self, value: int) -> None:
-        if value not in [1, 247]:
+        if value not in range(1, 248):
             raise ValueError("Invalid inverter unit ID.")
 
         self._inverter_unit_id = value
@@ -1705,7 +1705,7 @@ class SolarEdgeBattery:
 
     @inverter_unit_id.setter
     def inverter_unit_id(self, value: int) -> None:
-        if value not in [1, 247]:
+        if value not in range(1, 248):
             raise ValueError("Invalid inverter unit ID.")
 
         self._inverter_unit_id = value

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -483,7 +483,7 @@ class SolarEdgeModbusMultiHub:
 
         return True
 
-    def clear_offline_units(self) -> None:
+    def retry_offline_units(self) -> None:
         if self._offline_units:
             _LOGGER.debug(f"Retry offline units: {self._offline_units}")
             self._offline_units.clear()
@@ -1234,8 +1234,8 @@ class SolarEdgeInverter:
         """Write inverter register."""
         await self.hub.write_registers(self.inverter_unit_id, address, payload)
 
-    def clear_offline_units(self) -> None:
-        self.hub.clear_offline_units()
+    def retry_offline_units(self) -> None:
+        self.hub.retry_offline_units()
 
     @property
     def online(self) -> bool:

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1251,6 +1251,8 @@ class SolarEdgeMeter:
         self.inverter_common = self.hub.inverter_common[self.inverter_unit_id]
         self.mmppt_common = self.hub.mmppt_common[self.inverter_unit_id]
 
+        self._online = True
+
         if self.meter_id == 1:
             self.start_address = self.start_address + 121
         elif self.meter_id == 2:
@@ -1456,7 +1458,14 @@ class SolarEdgeMeter:
     @property
     def online(self) -> bool:
         """Device is online."""
-        return self.hub.online
+        return self.hub.online and self._online
+
+    @online.setter
+    def online(self, value: bool) -> None:
+        if value is True:
+            self._online = True
+        else:
+            self._online = False
 
     @property
     def inverter_unit_id(self) -> int:

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1234,6 +1234,9 @@ class SolarEdgeInverter:
         """Write inverter register."""
         await self.hub.write_registers(self.inverter_unit_id, address, payload)
 
+    def clear_offline_units(self) -> None:
+        self.hub.clear_offline_units()
+
     @property
     def online(self) -> bool:
         """Device is online."""


### PR DESCRIPTION
In a multi-inverter system, if any of the followers go offline skip them and keep updating inverters that are still online instead of going offline completely.