### PR TITLE
Change battery device check

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1522,8 +1522,8 @@ class SolarEdgeBattery:
 
         if (
             len(self.decoded_common["B_Manufacturer"]) == 0
-            or len(self.decoded_common["B_Model"]) == 0
-            or len(self.decoded_common["B_SerialNumber"]) == 0
+            and len(self.decoded_common["B_Model"]) == 0
+            and len(self.decoded_common["B_SerialNumber"]) == 0
         ):
             raise DeviceInvalid("Battery {self.battery_id} not usable.")
 


### PR DESCRIPTION
Change battery device check to 'and' since it was observed a battery stopped reporting one of the three device strings we were checking for to determine if a battery was attached in a slot or not.