### PR TITLE
Use battery rating value for detection

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1548,7 +1548,7 @@ class SolarEdgeBattery:
             "B_SerialNumber"
         ].translate(ascii_ctrl_chars)
 
-        if self.decoded_common["B_Device_Address"] == 0xFF or (
+        if (
             len(self.decoded_common["B_Manufacturer"]) == 0
             or len(self.decoded_common["B_Model"]) == 0
             or len(self.decoded_common["B_SerialNumber"]) == 0

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1551,9 +1551,9 @@ class SolarEdgeBattery:
         if (
             float_to_hex(self.decoded_common["B_RatedEnergy"])
             == hex(SunSpecNotImpl.FLOAT32)
-            or self.decoded_common["B_RatedEnergy"] < 0
+            or self.decoded_common["B_RatedEnergy"] <= 0
         ):
-            raise DeviceInvalid(f"Battery {self.battery_id} rating < 0")
+            raise DeviceInvalid(f"Battery {self.battery_id} not usable (rating <=0)")
 
         self.manufacturer = self.decoded_common["B_Manufacturer"]
         self.model = self.decoded_common["B_Model"]

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1549,7 +1549,7 @@ class SolarEdgeBattery:
         ].translate(ascii_ctrl_chars)
 
         if (
-            float_to_hex(self._platform.decoded_common["B_RatedEnergy"])
+            float_to_hex(self.decoded_common["B_RatedEnergy"])
             == hex(SunSpecNotImpl.FLOAT32)
             or self.decoded_common["B_RatedEnergy"] < 0
         ):

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1497,7 +1497,7 @@ class SolarEdgeBattery:
                         parse_modbus_string(decoder.decode_string(32)),
                     ),
                     ("B_Device_Address", decoder.decode_16bit_uint()),
-                    ("Reserved", decoder.decode_16bit_uint()),
+                    ("ignore", decoder.skip_bytes(2)),
                     ("B_RatedEnergy", decoder.decode_32bit_float()),
                     ("B_MaxChargePower", decoder.decode_32bit_float()),
                     ("B_MaxDischargePower", decoder.decode_32bit_float()),
@@ -1505,6 +1505,11 @@ class SolarEdgeBattery:
                     ("B_MaxDischargePeakPower", decoder.decode_32bit_float()),
                 ]
             )
+
+            try:
+                del self.decoded_common["ignore"]
+            except KeyError:
+                pass
 
             for name, value in iter(self.decoded_common.items()):
                 if isinstance(value, float):

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1549,11 +1549,11 @@ class SolarEdgeBattery:
         ].translate(ascii_ctrl_chars)
 
         if (
-            len(self.decoded_common["B_Manufacturer"]) == 0
-            or len(self.decoded_common["B_Model"]) == 0
-            or len(self.decoded_common["B_SerialNumber"]) == 0
+            float_to_hex(self._platform.decoded_common["B_RatedEnergy"])
+            == hex(SunSpecNotImpl.FLOAT32)
+            or self.decoded_common["B_RatedEnergy"] < 0
         ):
-            raise DeviceInvalid(f"Battery {self.battery_id} not usable.")
+            raise DeviceInvalid(f"Battery {self.battery_id} rating < 0")
 
         self.manufacturer = self.decoded_common["B_Manufacturer"]
         self.model = self.decoded_common["B_Model"]

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1548,7 +1548,7 @@ class SolarEdgeBattery:
             "B_SerialNumber"
         ].translate(ascii_ctrl_chars)
 
-        if (
+        if self.decoded_common["B_Device_Address"] == 0xFF or (
             len(self.decoded_common["B_Manufacturer"]) == 0
             or len(self.decoded_common["B_Model"]) == 0
             or len(self.decoded_common["B_SerialNumber"]) == 0


### PR DESCRIPTION
Use battery rating value for detection instead of make/model/firmware strings since there have been multiple reports one of the three strings returns blank. Current behavior requires all three to be >0 to detect a battery.

This PR moves away from make/model/firmware strings and uses reported capacity rating. If >0 then use battery, if <0 then mark as unusable.