### PR TITLE
Revert modbus client timeout option

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -83,10 +83,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             bool(ConfDefaultInt.BATTERY_ENERGY_RESET_CYCLES),
         ),
         entry.options.get(
-            ConfName.MODBUS_CLIENT_TIMEOUT,
-            ConfDefaultInt.MODBUS_CLIENT_TIMEOUT,
-        ),
-        entry.options.get(
             ConfName.ADV_PWR_CONTROL,
             bool(ConfDefaultFlag.ADV_PWR_CONTROL),
         ),

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -114,10 +114,6 @@ class SolaredgeModbusMultiOptionsFlowHandler(OptionsFlow):
                 errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
             elif user_input[CONF_SCAN_INTERVAL] > 86400:
                 errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
-            elif user_input[ConfName.MODBUS_CLIENT_TIMEOUT] < 3:
-                errors[ConfName.MODBUS_CLIENT_TIMEOUT] = "invalid_mb_client_timeout"
-            elif user_input[ConfName.MODBUS_CLIENT_TIMEOUT] > 10:
-                errors[ConfName.MODBUS_CLIENT_TIMEOUT] = "invalid_mb_client_timeout"
             else:
                 if user_input[ConfName.DETECT_BATTERIES] is True:
                     self.init_info = user_input
@@ -134,9 +130,6 @@ class SolaredgeModbusMultiOptionsFlowHandler(OptionsFlow):
             user_input = {
                 CONF_SCAN_INTERVAL: self.config_entry.options.get(
                     CONF_SCAN_INTERVAL, ConfDefaultInt.SCAN_INTERVAL
-                ),
-                ConfName.MODBUS_CLIENT_TIMEOUT: self.config_entry.options.get(
-                    ConfName.MODBUS_CLIENT_TIMEOUT, ConfDefaultInt.MODBUS_CLIENT_TIMEOUT
                 ),
                 ConfName.KEEP_MODBUS_OPEN: self.config_entry.options.get(
                     ConfName.KEEP_MODBUS_OPEN, bool(ConfDefaultFlag.KEEP_MODBUS_OPEN)
@@ -159,10 +152,6 @@ class SolaredgeModbusMultiOptionsFlowHandler(OptionsFlow):
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
                         default=user_input[CONF_SCAN_INTERVAL],
-                    ): vol.Coerce(int),
-                    vol.Optional(
-                        f"{ConfName.MODBUS_CLIENT_TIMEOUT}",
-                        default=user_input[ConfName.MODBUS_CLIENT_TIMEOUT],
                     ): vol.Coerce(int),
                     vol.Optional(
                         f"{ConfName.KEEP_MODBUS_OPEN}",

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -41,8 +41,9 @@ DOMAIN_REGEX = re.compile(
 
 
 class ModbusDefaults(IntEnum):
-    """Values for pymodbus library."""
+    """Values to pass to pymodbus"""
 
+    Timeout = 3  # Seconds to wait for a modbus response
     ReconnectDelay = 0  # Don't use pymodbus reconnect
 
 
@@ -85,7 +86,6 @@ class ConfDefaultInt(IntEnum):
     SLEEP_AFTER_WRITE = 0
     BATTERY_RATING_ADJUST = 0
     BATTERY_ENERGY_RESET_CYCLES = 0
-    MODBUS_CLIENT_TIMEOUT = 3
 
 
 class ConfDefaultFlag(IntEnum):
@@ -101,8 +101,6 @@ class ConfDefaultFlag(IntEnum):
 
 
 class ConfName(StrEnum):
-    """Configuration option names."""
-
     NUMBER_INVERTERS = "number_of_inverters"
     DEVICE_ID = "device_id"
     DETECT_METERS = "detect_meters"
@@ -115,7 +113,6 @@ class ConfName(StrEnum):
     SLEEP_AFTER_WRITE = "sleep_after_write"
     BATTERY_RATING_ADJUST = "battery_rating_adjust"
     BATTERY_ENERGY_RESET_CYCLES = "battery_energy_reset_cycles"
-    MODBUS_CLIENT_TIMEOUT = "mb_client_timeout"
 
 
 class SunSpecAccum(IntEnum):

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -144,7 +144,6 @@ class SolarEdgeModbusMultiHub:
         self._initalized = False
         self._online = True
 
-        self._mb_client_timeout = ModbusDefaults.Timeout
         self._client = None
 
         _LOGGER.debug(
@@ -558,11 +557,6 @@ class SolarEdgeModbusMultiHub:
         return this_timeout
 
     @property
-    def mb_client_timeout(self) -> int:
-        _LOGGER.debug(f"modbus client timeout is {self._mb_client_timeout}")
-        return self._mb_client_timeout
-
-    @property
     def is_connected(self) -> bool:
         """Check modbus client connection status."""
         if self._client is None:
@@ -582,7 +576,7 @@ class SolarEdgeModbusMultiHub:
                     host=self._host,
                     port=self._port,
                     reconnect_delay=ModbusDefaults.ReconnectDelay,
-                    timeout=self.mb_client_timeout,
+                    timeout=ModbusDefaults.Timeout,
                 )
 
             await self._client.connect()

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -109,7 +109,6 @@ class SolarEdgeModbusMultiHub:
         sleep_after_write: int = 3,
         battery_rating_adjust: int = 0,
         battery_energy_reset_cycles: int = 0,
-        mb_client_timeout: int = 3,
         adv_power_control: bool = False,
     ):
         """Initialize the Modbus hub."""
@@ -129,7 +128,6 @@ class SolarEdgeModbusMultiHub:
         self._sleep_after_write = sleep_after_write
         self._battery_rating_adjust = battery_rating_adjust
         self._battery_energy_reset_cycles = battery_energy_reset_cycles
-        self._mb_client_timeout = mb_client_timeout
         self._adv_power_control = adv_power_control
         self._id = name.lower()
         self._lock = asyncio.Lock()
@@ -146,6 +144,7 @@ class SolarEdgeModbusMultiHub:
         self._initalized = False
         self._online = True
 
+        self._mb_client_timeout = ModbusDefaults.Timeout
         self._client = None
 
         _LOGGER.debug(
@@ -161,7 +160,6 @@ class SolarEdgeModbusMultiHub:
                 f"allow_battery_energy_reset={self._allow_battery_energy_reset}, "
                 f"sleep_after_write={self._sleep_after_write}, "
                 f"battery_rating_adjust={self._battery_rating_adjust}, "
-                f"mb_client_timeout={self._mb_client_timeout}, "
                 f"adv_power_control={self._adv_power_control}"
             ),
         )

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -35,8 +35,7 @@
           "keep_modbus_open": "Keep Modbus Connection Open",
           "detect_meters": "Auto-Detect Meters",
           "detect_batteries": "Auto-Detect Batteries",
-          "advanced_power_control": "Power Control Options",
-          "mb_client_timeout": "Modbus Client Timeout"
+          "advanced_power_control": "Power Control Options"
         }
       },
       "adv_pwr_ctl": {
@@ -60,8 +59,7 @@
     "error": {
       "invalid_scan_interval": "Valid interval is 1 to 86400 seconds.",
       "invalid_sleep_interval": "Valid interval is 0 to 60 seconds.",
-      "invalid_percent": "Valid range is 0 to 100 percent.",
-      "invalid_mb_client_timeout": "Valid timeout is 3 to 10 seconds."
+      "invalid_percent": "Valid range is 0 to 100 percent."
     }
   },
   "issues": {

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -35,8 +35,7 @@
           "keep_modbus_open": "Modbus-Verbindung geöffnet lassen",
           "detect_meters": "Messgeräte automatisch erkennen",
           "detect_batteries": "Batterien automatisch erkennen",
-          "advanced_power_control": "Erweiterte Leistungssteuerung",
-          "mb_client_timeout": "Zeitüberschreitung des Modbus-Clients"
+          "advanced_power_control": "Erweiterte Leistungssteuerung"
         }
       },
       "adv_pwr_ctl": {
@@ -60,8 +59,7 @@
     "error": {
       "invalid_scan_interval": "Gültiges Intervall ist 1 bis 86400 Sekunden.",
       "invalid_sleep_interval": "Gültiges Intervall ist 0 bis 60 Sekunden.",
-      "invalid_percent": "Gültiges Bereich ist 0 bis 100 Prozent.",
-      "invalid_mb_client_timeout": "Das gültige Timeout beträgt 3 bis 10 Sekunden."
+      "invalid_percent": "Gültiges Bereich ist 0 bis 100 Prozent."
     }
   },
   "issues": {

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -35,8 +35,7 @@
           "keep_modbus_open": "Keep Modbus Connection Open",
           "detect_meters": "Auto-Detect Meters",
           "detect_batteries": "Auto-Detect Batteries",
-          "advanced_power_control": "Power Control Options",
-          "mb_client_timeout": "Modbus Client Timeout"
+          "advanced_power_control": "Power Control Options"
         }
       },
       "adv_pwr_ctl": {
@@ -60,8 +59,7 @@
     "error": {
       "invalid_scan_interval": "Valid interval is 1 to 86400 seconds.",
       "invalid_sleep_interval": "Valid interval is 0 to 60 seconds.",
-      "invalid_percent": "Valid range is 0 to 100 percent.",
-      "invalid_mb_client_timeout": "Valid timeout is 3 to 10 seconds."
+      "invalid_percent": "Valid range is 0 to 100 percent."
     }
   },
   "issues": {

--- a/custom_components/solaredge_modbus_multi/translations/fr.json
+++ b/custom_components/solaredge_modbus_multi/translations/fr.json
@@ -35,8 +35,7 @@
           "keep_modbus_open": "Garder la connection Modbus ouverte",
           "detect_meters": "Auto-détecter les capteurs",
           "detect_batteries": "Auto-détecter les batteries",
-          "advanced_power_control": "Options de contrôle de l'alimentation",
-          "mb_client_timeout": "Délai d'expiration du client Modbus"
+          "advanced_power_control": "Options de contrôle de l'alimentation"
         }
       },
       "adv_pwr_ctl": {
@@ -60,8 +59,7 @@
     "error": {
       "invalid_scan_interval": "L'intervalle valide est de 1 à 86 400 secondes.",
       "invalid_sleep_interval": "L'intervalle valide est de 0 à 60 secondes.",
-      "invalid_percent": "La plage valide est de 0 à 100 %.",
-      "invalid_mb_client_timeout": "Le délai d'attente valide est de 3 à 10 secondes."
+      "invalid_percent": "La plage valide est de 0 à 100 %."
     }
   },
   "issues": {

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -35,8 +35,7 @@
           "keep_modbus_open": "Hold Modbus-tilkoblingen åpen",
           "detect_meters": "Automatisk oppdagelse av målere",
           "detect_batteries": "Automatisk gjenkjenning av batterier",
-          "advanced_power_control": "Avansert strømkontroll",
-          "mb_client_timeout": "Modbus Client Timeout"
+          "advanced_power_control": "Avansert strømkontroll"
         }
       },
       "adv_pwr_ctl": {
@@ -60,8 +59,7 @@
     "error": {
       "invalid_scan_interval": "Gyldig intervall er 1 til 86400 sekunder.",
       "invalid_sleep_interval": "Gyldig intervall er 0 til 60 sekunder.",
-      "invalid_percent": "Gyldig område er 0 til 100 prosent.",
-      "invalid_mb_client_timeout": "Gyldig tidsavbrudd er 3 til 10 sekunder."
+      "invalid_percent": "Gyldig område er 0 til 100 prosent."
     }
   },
   "issues": {

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -35,8 +35,7 @@
           "keep_modbus_open": "Houd Modbus-verbinding open",
           "detect_meters": "Meters automatisch detecteren",
           "detect_batteries": "Batterijen automatisch detecteren",
-          "advanced_power_control": "Geavanceerde stroomregeling",
-          "mb_client_timeout": "Modbus-client time-out"
+          "advanced_power_control": "Geavanceerde stroomregeling"
         }
       },
       "adv_pwr_ctl": {
@@ -60,8 +59,7 @@
     "error": {
       "invalid_scan_interval": "Geldig interval is 1 tot 86400 seconden.",
       "invalid_sleep_interval": "Geldig interval is 0 tot 60 seconden.",
-      "invalid_percent": "Het geldige bereik is 0 tot 100 procent.",
-      "invalid_mb_client_timeout": "Geldige time-out is 3 tot 10 seconden."
+      "invalid_percent": "Het geldige bereik is 0 tot 100 procent."
     }
   },
   "issues": {

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -35,8 +35,7 @@
           "keep_modbus_open": "Pozostaw połączenie Modbus otwarte",
           "detect_meters": "Automatycznie wykryj liczniki",
           "detect_batteries": "Automatycznie wykryj baterie",
-          "advanced_power_control": "Zaawansowana kontrola mocy",
-          "mb_client_timeout": "Limit czasu klienta Modbus"
+          "advanced_power_control": "Zaawansowana kontrola mocy"
         }
       },
       "adv_pwr_ctl": {
@@ -60,8 +59,7 @@
     "error": {
       "invalid_scan_interval": "Próbkowanie musi być w zakresie od 1 do 86400 sekund.",
       "invalid_sleep_interval": "Próbkowanie musi być w zakresie od 0 do 60 sekund.",
-      "invalid_percent": "Prawidłowy zakres wynosi od 0 do 100 procent.",
-      "invalid_mb_client_timeout": "Prawidłowy limit czasu wynosi od 3 do 10 sekund."
+      "invalid_percent": "Prawidłowy zakres wynosi od 0 do 100 procent."
     }
   },
   "issues": {


### PR DESCRIPTION
Solution to issue #394 is to make discovery of additional functions a config option since increasing timeout did not work (at least version 3.3.1 of pymodbus).