### PR TITLE
Auto-Detect Additional Entities Option

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -86,10 +86,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ConfName.MODBUS_CLIENT_TIMEOUT,
             ConfDefaultInt.MODBUS_CLIENT_TIMEOUT,
         ),
-        entry.options.get(
-            ConfName.ADV_PWR_CONTROL,
-            bool(ConfDefaultFlag.ADV_PWR_CONTROL),
-        ),
     )
 
     coordinator = SolarEdgeCoordinator(

--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -60,6 +60,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.options.get(
             ConfName.DETECT_BATTERIES, bool(ConfDefaultFlag.DETECT_BATTERIES)
         ),
+        entry.options.get(ConfName.DETECT_EXTRAS, bool(ConfDefaultFlag.DETECT_EXTRAS)),
         entry.options.get(
             ConfName.KEEP_MODBUS_OPEN, bool(ConfDefaultFlag.KEEP_MODBUS_OPEN)
         ),

--- a/custom_components/solaredge_modbus_multi/binary_sensor.py
+++ b/custom_components/solaredge_modbus_multi/binary_sensor.py
@@ -26,7 +26,7 @@ async def async_setup_entry(
     entities = []
 
     for inverter in hub.inverters:
-        if inverter.advanced_power_control:
+        if hub.option_detect_extras and inverter.advanced_power_control:
             entities.append(AdvPowerControlEnabled(inverter, config_entry, coordinator))
 
     if entities:

--- a/custom_components/solaredge_modbus_multi/binary_sensor.py
+++ b/custom_components/solaredge_modbus_multi/binary_sensor.py
@@ -26,10 +26,7 @@ async def async_setup_entry(
     entities = []
 
     for inverter in hub.inverters:
-        if (
-            hub.option_advanced_power_control is True
-            and inverter.advanced_power_control
-        ):
+        if inverter.advanced_power_control:
             entities.append(AdvPowerControlEnabled(inverter, config_entry, coordinator))
 
     if entities:

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -140,6 +140,9 @@ class SolaredgeModbusMultiOptionsFlowHandler(OptionsFlow):
                 ConfName.DETECT_BATTERIES: self.config_entry.options.get(
                     ConfName.DETECT_BATTERIES, bool(ConfDefaultFlag.DETECT_BATTERIES)
                 ),
+                ConfName.DETECT_EXTRAS: self.config_entry.options.get(
+                    ConfName.DETECT_EXTRAS, bool(ConfDefaultFlag.DETECT_EXTRAS)
+                ),
                 ConfName.ADV_PWR_CONTROL: self.config_entry.options.get(
                     ConfName.ADV_PWR_CONTROL, bool(ConfDefaultFlag.ADV_PWR_CONTROL)
                 ),
@@ -164,6 +167,10 @@ class SolaredgeModbusMultiOptionsFlowHandler(OptionsFlow):
                     vol.Optional(
                         f"{ConfName.DETECT_BATTERIES}",
                         default=user_input[ConfName.DETECT_BATTERIES],
+                    ): cv.boolean,
+                    vol.Optional(
+                        f"{ConfName.DETECT_EXTRAS}",
+                        default=user_input[ConfName.DETECT_EXTRAS],
                     ): cv.boolean,
                     vol.Optional(
                         f"{ConfName.ADV_PWR_CONTROL}",

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -93,6 +93,7 @@ class ConfDefaultFlag(IntEnum):
 
     DETECT_METERS = 1
     DETECT_BATTERIES = 0
+    DETECT_EXTRAS = 1
     KEEP_MODBUS_OPEN = 0
     ADV_PWR_CONTROL = 0
     ADV_STORAGE_CONTROL = 0
@@ -105,6 +106,7 @@ class ConfName(StrEnum):
     DEVICE_ID = "device_id"
     DETECT_METERS = "detect_meters"
     DETECT_BATTERIES = "detect_batteries"
+    DETECT_EXTRAS = "detect_extras"
     KEEP_MODBUS_OPEN = "keep_modbus_open"
     ADV_PWR_CONTROL = "advanced_power_control"
     ADV_STORAGE_CONTROL = "adv_storage_control"

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -978,7 +978,9 @@ class SolarEdgeInverter:
                 )
 
         """ Global Dynamic Power Control and Status """
-        if self.global_power_control is True or self.global_power_control is None:
+        if self.hub.option_detect_extras is True and (
+            self.global_power_control is True or self.global_power_control is None
+        ):
             try:
                 inverter_data = await self.hub.modbus_read_holding_registers(
                     unit=self.inverter_unit_id, address=61440, rcount=4
@@ -1016,7 +1018,9 @@ class SolarEdgeInverter:
                 )
 
         """ Advanced Power Control """
-        if self.advanced_power_control is True or self.advanced_power_control is None:
+        if self.hub.option_detect_extras is True and (
+            self.advanced_power_control is True or self.advanced_power_control is None
+        ):
             try:
                 inverter_data = await self.hub.modbus_read_holding_registers(
                     unit=self.inverter_unit_id, address=61762, rcount=2

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -102,6 +102,7 @@ class SolarEdgeModbusMultiHub:
         start_device_id: int = 1,
         detect_meters: bool = True,
         detect_batteries: bool = False,
+        detect_extras: bool = True,
         keep_modbus_open: bool = False,
         adv_storage_control: bool = False,
         adv_site_limit_control: bool = False,
@@ -120,6 +121,7 @@ class SolarEdgeModbusMultiHub:
         self._start_device_id = start_device_id
         self._detect_meters = detect_meters
         self._detect_batteries = detect_batteries
+        self._detect_extras = detect_extras
         self._keep_modbus_open = keep_modbus_open
         self._adv_storage_control = adv_storage_control
         self._adv_site_limit_control = adv_site_limit_control
@@ -127,6 +129,7 @@ class SolarEdgeModbusMultiHub:
         self._sleep_after_write = sleep_after_write
         self._battery_rating_adjust = battery_rating_adjust
         self._battery_energy_reset_cycles = battery_energy_reset_cycles
+
         self._id = name.lower()
         self._lock = asyncio.Lock()
         self.inverters = []
@@ -151,6 +154,7 @@ class SolarEdgeModbusMultiHub:
                 f"start_device_id={self._start_device_id}, "
                 f"detect_meters={self._detect_meters}, "
                 f"detect_batteries={self._detect_batteries}, "
+                f"detect_extras={self._detect_extras}, "
                 f"keep_modbus_open={self._keep_modbus_open}, "
                 f"adv_storage_control={self._adv_storage_control}, "
                 f"adv_site_limit_control={self._adv_site_limit_control}, "
@@ -477,6 +481,10 @@ class SolarEdgeModbusMultiHub:
     @property
     def option_site_limit_control(self) -> bool:
         return self._adv_site_limit_control
+
+    @property
+    def option_detect_extras(self) -> bool:
+        return self._detect_extras
 
     @property
     def keep_modbus_open(self) -> bool:

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -110,7 +110,6 @@ class SolarEdgeModbusMultiHub:
         battery_rating_adjust: int = 0,
         battery_energy_reset_cycles: int = 0,
         mb_client_timeout: int = 3,
-        adv_power_control: bool = False,
     ):
         """Initialize the Modbus hub."""
         self._hass = hass
@@ -130,7 +129,6 @@ class SolarEdgeModbusMultiHub:
         self._battery_rating_adjust = battery_rating_adjust
         self._battery_energy_reset_cycles = battery_energy_reset_cycles
         self._mb_client_timeout = mb_client_timeout
-        self._adv_power_control = adv_power_control
         self._id = name.lower()
         self._lock = asyncio.Lock()
         self.inverters = []
@@ -162,7 +160,6 @@ class SolarEdgeModbusMultiHub:
                 f"sleep_after_write={self._sleep_after_write}, "
                 f"battery_rating_adjust={self._battery_rating_adjust}, "
                 f"mb_client_timeout={self._mb_client_timeout}, "
-                f"adv_power_control={self._adv_power_control}"
             ),
         )
 
@@ -483,10 +480,6 @@ class SolarEdgeModbusMultiHub:
     @property
     def option_site_limit_control(self) -> bool:
         return self._adv_site_limit_control
-
-    @property
-    def option_advanced_power_control(self) -> bool:
-        return self._adv_power_control
 
     @property
     def keep_modbus_open(self) -> bool:
@@ -985,9 +978,7 @@ class SolarEdgeInverter:
                 )
 
         """ Global Dynamic Power Control and Status """
-        if self.hub.option_advanced_power_control and (
-            self.global_power_control is True or self.global_power_control is None
-        ):
+        if self.global_power_control is True or self.global_power_control is None:
             try:
                 inverter_data = await self.hub.modbus_read_holding_registers(
                     unit=self.inverter_unit_id, address=61440, rcount=4
@@ -1025,9 +1016,7 @@ class SolarEdgeInverter:
                 )
 
         """ Advanced Power Control """
-        if self.hub.option_advanced_power_control and (
-            self.advanced_power_control is True or self.advanced_power_control is None
-        ):
+        if self.advanced_power_control is True or self.advanced_power_control is None:
             try:
                 inverter_data = await self.hub.modbus_read_holding_registers(
                     unit=self.inverter_unit_id, address=61762, rcount=2

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -83,14 +83,9 @@ async def async_setup_entry(
         entities.append(DCVoltage(inverter, config_entry, coordinator))
         entities.append(DCPower(inverter, config_entry, coordinator))
         entities.append(HeatSinkTemperature(inverter, config_entry, coordinator))
-
-        if hub.option_advanced_power_control is True:
-            entities.append(SolarEdgeRRCR(inverter, config_entry, coordinator))
-            entities.append(
-                SolarEdgeActivePowerLimit(inverter, config_entry, coordinator)
-            )
-            entities.append(SolarEdgeCosPhi(inverter, config_entry, coordinator))
-
+        entities.append(SolarEdgeRRCR(inverter, config_entry, coordinator))
+        entities.append(SolarEdgeActivePowerLimit(inverter, config_entry, coordinator))
+        entities.append(SolarEdgeCosPhi(inverter, config_entry, coordinator))
         if inverter.is_mmppt:
             entities.append(SolarEdgeMMPPTEvents(inverter, config_entry, coordinator))
 

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -83,9 +83,14 @@ async def async_setup_entry(
         entities.append(DCVoltage(inverter, config_entry, coordinator))
         entities.append(DCPower(inverter, config_entry, coordinator))
         entities.append(HeatSinkTemperature(inverter, config_entry, coordinator))
-        entities.append(SolarEdgeRRCR(inverter, config_entry, coordinator))
-        entities.append(SolarEdgeActivePowerLimit(inverter, config_entry, coordinator))
-        entities.append(SolarEdgeCosPhi(inverter, config_entry, coordinator))
+
+        if hub.option_detect_extras:
+            entities.append(SolarEdgeRRCR(inverter, config_entry, coordinator))
+            entities.append(
+                SolarEdgeActivePowerLimit(inverter, config_entry, coordinator)
+            )
+            entities.append(SolarEdgeCosPhi(inverter, config_entry, coordinator))
+
         if inverter.is_mmppt:
             entities.append(SolarEdgeMMPPTEvents(inverter, config_entry, coordinator))
 

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -35,6 +35,7 @@
           "keep_modbus_open": "Keep Modbus Connection Open",
           "detect_meters": "Auto-Detect Meters",
           "detect_batteries": "Auto-Detect Batteries",
+          "detect_extras": "Auto-Detect Additional Entities",
           "advanced_power_control": "Power Control Options"
         }
       },

--- a/custom_components/solaredge_modbus_multi/switch.py
+++ b/custom_components/solaredge_modbus_multi/switch.py
@@ -38,7 +38,7 @@ async def async_setup_entry(
                 SolarEdgeNegativeSiteLimit(inverter, config_entry, coordinator)
             )
 
-        if inverter.advanced_power_control:
+        if hub.option_detect_extras and inverter.advanced_power_control:
             entities.append(SolarEdgeGridControl(inverter, config_entry, coordinator))
 
     if entities:

--- a/custom_components/solaredge_modbus_multi/switch.py
+++ b/custom_components/solaredge_modbus_multi/switch.py
@@ -38,10 +38,7 @@ async def async_setup_entry(
                 SolarEdgeNegativeSiteLimit(inverter, config_entry, coordinator)
             )
 
-        if (
-            hub.option_advanced_power_control is True
-            and inverter.advanced_power_control
-        ):
+        if inverter.advanced_power_control:
             entities.append(SolarEdgeGridControl(inverter, config_entry, coordinator))
 
     if entities:

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -35,6 +35,7 @@
           "keep_modbus_open": "Modbus-Verbindung geöffnet lassen",
           "detect_meters": "Messgeräte automatisch erkennen",
           "detect_batteries": "Batterien automatisch erkennen",
+          "detect_extras": "Zusätzliche Entitäten automatisch erkennen",
           "advanced_power_control": "Erweiterte Leistungssteuerung"
         }
       },

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -35,6 +35,7 @@
           "keep_modbus_open": "Keep Modbus Connection Open",
           "detect_meters": "Auto-Detect Meters",
           "detect_batteries": "Auto-Detect Batteries",
+          "detect_extras": "Auto-Detect Additional Entities",
           "advanced_power_control": "Power Control Options"
         }
       },

--- a/custom_components/solaredge_modbus_multi/translations/fr.json
+++ b/custom_components/solaredge_modbus_multi/translations/fr.json
@@ -35,6 +35,7 @@
           "keep_modbus_open": "Garder la connection Modbus ouverte",
           "detect_meters": "Auto-détecter les capteurs",
           "detect_batteries": "Auto-détecter les batteries",
+          "detect_extras": "Détection automatique des entités supplémentaires",
           "advanced_power_control": "Options de contrôle de l'alimentation"
         }
       },

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -35,6 +35,7 @@
           "keep_modbus_open": "Hold Modbus-tilkoblingen åpen",
           "detect_meters": "Automatisk oppdagelse av målere",
           "detect_batteries": "Automatisk gjenkjenning av batterier",
+          "detect_extras": "Automatisk oppdage flere enheter",
           "advanced_power_control": "Avansert strømkontroll"
         }
       },

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -35,6 +35,7 @@
           "keep_modbus_open": "Houd Modbus-verbinding open",
           "detect_meters": "Meters automatisch detecteren",
           "detect_batteries": "Batterijen automatisch detecteren",
+          "detect_extras": "Automatische detectie van aanvullende entiteiten",
           "advanced_power_control": "Geavanceerde stroomregeling"
         }
       },

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -35,6 +35,7 @@
           "keep_modbus_open": "Pozostaw połączenie Modbus otwarte",
           "detect_meters": "Automatycznie wykryj liczniki",
           "detect_batteries": "Automatycznie wykryj baterie",
+          "detect_extras": "Automatycznie wykrywaj dodatkowe elementy",
           "advanced_power_control": "Zaawansowana kontrola mocy"
         }
       },


### PR DESCRIPTION
Make discovery reads for advanced power control and global power control a config option. Default enabled (current behavior).

Replaces PR #413

Disable this option as a workaround for issue #394