### PR TITLE
Add dynamic power control settings

### DIFF
--- a/custom_components/solaredge_modbus_multi/number.py
+++ b/custom_components/solaredge_modbus_multi/number.py
@@ -502,10 +502,7 @@ class SolarEdgeActivePowerLimitSet(SolarEdgeNumberBase):
 
     @property
     def entity_registry_enabled_default(self) -> bool:
-        if self._platform.global_power_control is True:
-            return True
-        else:
-            return False
+        return self._platform.global_power_control
 
     @property
     def available(self) -> bool:

--- a/custom_components/solaredge_modbus_multi/number.py
+++ b/custom_components/solaredge_modbus_multi/number.py
@@ -28,6 +28,13 @@ async def async_setup_entry(
 
     entities = []
 
+    for inverter in hub.inverters:
+        if hub.option_detect_extras:
+            entities.append(
+                SolarEdgeActivePowerLimitSet(inverter, config_entry, coordinator)
+            )
+            entities.append(SolarEdgeCosPhiSet(inverter, config_entry, coordinator))
+
     """ Power Control Options: Storage Control """
     if hub.option_storage_control is True:
         for inverter in hub.inverters:
@@ -469,5 +476,115 @@ class SolarEdgeExternalProductionMax(SolarEdgeNumberBase):
         builder.add_32bit_float(float(value))
         await self._platform.write_registers(
             address=57362, payload=builder.to_registers()
+        )
+        await self.async_update()
+
+
+class SolarEdgeActivePowerLimitSet(SolarEdgeNumberBase):
+    """Global Dynamic Power Control: Set Inverter Active Power Limit"""
+
+    native_unit_of_measurement = PERCENTAGE
+    native_min_value = 0
+    native_max_value = 100
+    mode = "slider"
+    icon = "mdi:percent"
+
+    def __init__(self, inverter, config_entry, coordinator):
+        super().__init__(inverter, config_entry, coordinator)
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_active_power_limit_set"
+
+    @property
+    def name(self) -> str:
+        return "Active Power Limit"
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        if self._platform.global_power_control is True:
+            return True
+        else:
+            return False
+
+    @property
+    def available(self) -> bool:
+        try:
+            if (
+                self._platform.decoded_model["I_Power_Limit"] == SunSpecNotImpl.UINT16
+                or self._platform.decoded_model["I_Power_Limit"] > 100
+                or self._platform.decoded_model["I_Power_Limit"] < 0
+            ):
+                return False
+
+            return super().available
+
+        except KeyError:
+            return False
+
+    @property
+    def native_value(self) -> int:
+        return self._platform.decoded_model["I_Power_Limit"]
+
+    async def async_set_native_value(self, value: float) -> None:
+        _LOGGER.debug(f"set {self.unique_id} to {value}")
+        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder.add_16bit_uint(int(value))
+        await self._platform.write_registers(
+            address=61441, payload=builder.to_registers()
+        )
+        await self.async_update()
+
+
+class SolarEdgeCosPhiSet(SolarEdgeNumberBase):
+    """Global Dynamic Power Control: Set Inverter CosPhi"""
+
+    native_min_value = -1.0
+    native_max_value = 1.0
+    native_step = 0.1
+    mode = "slider"
+    icon = "mdi:angle-acute"
+
+    def __init__(self, inverter, config_entry, coordinator):
+        super().__init__(inverter, config_entry, coordinator)
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_cosphi_set"
+
+    @property
+    def name(self) -> str:
+        return "CosPhi"
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        return False
+
+    @property
+    def available(self) -> bool:
+        try:
+            if (
+                float_to_hex(self._platform.decoded_model["I_CosPhi"])
+                == hex(SunSpecNotImpl.FLOAT32)
+                or self._platform.decoded_model["I_CosPhi"] > 1.0
+                or self._platform.decoded_model["I_CosPhi"] < -1.0
+            ):
+                return False
+
+            return super().available
+
+        except KeyError:
+            return False
+
+    @property
+    def native_value(self):
+        return round(self._platform.decoded_model["I_CosPhi"], 1)
+
+    async def async_set_native_value(self, value: float) -> None:
+        _LOGGER.debug(f"set {self.unique_id} to {value}")
+        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder.add_32bit_float(float(value))
+        await self._platform.write_registers(
+            address=61442, payload=builder.to_registers()
         )
         await self.async_update()

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1304,6 +1304,8 @@ class SolarEdgeRRCR(SolarEdgeGlobalPowerControlBlock):
 
 
 class SolarEdgeActivePowerLimit(SolarEdgeGlobalPowerControlBlock):
+    """Global Dynamic Power Control: Inverter Active Power Limit"""
+
     state_class = SensorStateClass.MEASUREMENT
     native_unit_of_measurement = PERCENTAGE
     suggested_display_precision = 0
@@ -1323,10 +1325,7 @@ class SolarEdgeActivePowerLimit(SolarEdgeGlobalPowerControlBlock):
 
     @property
     def entity_registry_enabled_default(self) -> bool:
-        if self._platform.global_power_control is True:
-            return True
-        else:
-            return False
+        return self._platform.global_power_control
 
     @property
     def native_value(self):
@@ -1346,6 +1345,8 @@ class SolarEdgeActivePowerLimit(SolarEdgeGlobalPowerControlBlock):
 
 
 class SolarEdgeCosPhi(SolarEdgeGlobalPowerControlBlock):
+    """Global Dynamic Power Control: Inverter CosPhi"""
+
     state_class = SensorStateClass.MEASUREMENT
     suggested_display_precision = 1
     icon = "mdi:angle-acute"
@@ -1364,7 +1365,7 @@ class SolarEdgeCosPhi(SolarEdgeGlobalPowerControlBlock):
 
     @property
     def entity_registry_enabled_default(self) -> bool:
-        return False
+        return self._platform.global_power_control
 
     @property
     def native_value(self):


### PR DESCRIPTION
Add number entities to set Active Power Limit (default enabled) and CosPhi (default disabled) values.

Add docstrings and update registry defaults for matching sensor entities (enabled by default when available).