### PR TITLE
Move inverter command delay option to top level

### DIFF
--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -114,6 +114,10 @@ class SolaredgeModbusMultiOptionsFlowHandler(OptionsFlow):
                 errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
             elif user_input[CONF_SCAN_INTERVAL] > 86400:
                 errors[CONF_SCAN_INTERVAL] = "invalid_scan_interval"
+            elif user_input[ConfName.SLEEP_AFTER_WRITE] < 0:
+                errors[ConfName.SLEEP_AFTER_WRITE] = "invalid_sleep_interval"
+            elif user_input[ConfName.SLEEP_AFTER_WRITE] > 60:
+                errors[ConfName.SLEEP_AFTER_WRITE] = "invalid_sleep_interval"
             else:
                 if user_input[ConfName.DETECT_BATTERIES] is True:
                     self.init_info = user_input
@@ -146,6 +150,9 @@ class SolaredgeModbusMultiOptionsFlowHandler(OptionsFlow):
                 ConfName.ADV_PWR_CONTROL: self.config_entry.options.get(
                     ConfName.ADV_PWR_CONTROL, bool(ConfDefaultFlag.ADV_PWR_CONTROL)
                 ),
+                ConfName.SLEEP_AFTER_WRITE: self.config_entry.options.get(
+                    ConfName.SLEEP_AFTER_WRITE, ConfDefaultInt.SLEEP_AFTER_WRITE
+                ),
             }
 
         return self.async_show_form(
@@ -176,6 +183,10 @@ class SolaredgeModbusMultiOptionsFlowHandler(OptionsFlow):
                         f"{ConfName.ADV_PWR_CONTROL}",
                         default=user_input[ConfName.ADV_PWR_CONTROL],
                     ): cv.boolean,
+                    vol.Optional(
+                        f"{ConfName.SLEEP_AFTER_WRITE}",
+                        default=user_input[ConfName.SLEEP_AFTER_WRITE],
+                    ): vol.Coerce(int),
                 },
             ),
             errors=errors,
@@ -241,14 +252,9 @@ class SolaredgeModbusMultiOptionsFlowHandler(OptionsFlow):
         errors = {}
 
         if user_input is not None:
-            if user_input[ConfName.SLEEP_AFTER_WRITE] < 0:
-                errors[ConfName.SLEEP_AFTER_WRITE] = "invalid_sleep_interval"
-            elif user_input[ConfName.SLEEP_AFTER_WRITE] > 60:
-                errors[ConfName.SLEEP_AFTER_WRITE] = "invalid_sleep_interval"
-            else:
-                return self.async_create_entry(
-                    title="", data={**self.init_info, **user_input}
-                )
+            return self.async_create_entry(
+                title="", data={**self.init_info, **user_input}
+            )
 
         else:
             user_input = {
@@ -259,9 +265,6 @@ class SolaredgeModbusMultiOptionsFlowHandler(OptionsFlow):
                 ConfName.ADV_SITE_LIMIT_CONTROL: self.config_entry.options.get(
                     ConfName.ADV_SITE_LIMIT_CONTROL,
                     bool(ConfDefaultFlag.ADV_SITE_LIMIT_CONTROL),
-                ),
-                ConfName.SLEEP_AFTER_WRITE: self.config_entry.options.get(
-                    ConfName.SLEEP_AFTER_WRITE, ConfDefaultInt.SLEEP_AFTER_WRITE
                 ),
             }
 
@@ -277,10 +280,6 @@ class SolaredgeModbusMultiOptionsFlowHandler(OptionsFlow):
                         f"{ConfName.ADV_SITE_LIMIT_CONTROL}",
                         default=user_input[ConfName.ADV_SITE_LIMIT_CONTROL],
                     ): cv.boolean,
-                    vol.Optional(
-                        f"{ConfName.SLEEP_AFTER_WRITE}",
-                        default=user_input[ConfName.SLEEP_AFTER_WRITE],
-                    ): vol.Coerce(int),
                 }
             ),
             errors=errors,

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -36,15 +36,15 @@
           "detect_meters": "Auto-Detect Meters",
           "detect_batteries": "Auto-Detect Batteries",
           "detect_extras": "Auto-Detect Additional Entities",
-          "advanced_power_control": "Power Control Options"
+          "advanced_power_control": "Power Control Options",
+          "sleep_after_write": "Inverter Command Delay (seconds)"
         }
       },
       "adv_pwr_ctl": {
         "title": "Power Control Options",
         "data": {
           "adv_storage_control": "Enable Storage Control",
-          "adv_site_limit_control": "Enable Site Limit Control",
-          "sleep_after_write": "Inverter Command Delay (seconds)"
+          "adv_site_limit_control": "Enable Site Limit Control"
         },
         "description": "Warning: These options can violate utility agreements, alter your utility billing, may require special equipment, and overwrite provisioning by SolarEdge or your installer. Use at your own risk!"
       },

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -36,15 +36,15 @@
           "detect_meters": "Messgeräte automatisch erkennen",
           "detect_batteries": "Batterien automatisch erkennen",
           "detect_extras": "Zusätzliche Entitäten automatisch erkennen",
-          "advanced_power_control": "Erweiterte Leistungssteuerung"
+          "advanced_power_control": "Erweiterte Leistungssteuerung",
+          "sleep_after_write": "Befehlsverzögerung des Wechselrichters (Sekunden)"
         }
       },
       "adv_pwr_ctl": {
         "title": "Energiesteuerungsoptionen",
         "data": {
           "adv_storage_control": "Speichersteuerung aktivieren",
-          "adv_site_limit_control": "Site-Limit-Kontrolle aktivieren",
-          "sleep_after_write": "Befehlsverzögerung des Wechselrichters (Sekunden)"
+          "adv_site_limit_control": "Site-Limit-Kontrolle aktivieren"
         },
         "description": "Warnung: Diese Optionen können gegen Stromverträge verstoßen, Ihre Stromabrechnung ändern, möglicherweise spezielle Geräte erfordern und die Bereitstellung durch SolarEdge oder Ihren Installateur überschreiben. Benutzung auf eigene Gefahr!"
       },

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -36,15 +36,15 @@
           "detect_meters": "Auto-Detect Meters",
           "detect_batteries": "Auto-Detect Batteries",
           "detect_extras": "Auto-Detect Additional Entities",
-          "advanced_power_control": "Power Control Options"
+          "advanced_power_control": "Power Control Options",
+          "sleep_after_write": "Inverter Command Delay (seconds)"
         }
       },
       "adv_pwr_ctl": {
         "title": "Power Control Options",
         "data": {
           "adv_storage_control": "Enable Storage Control",
-          "adv_site_limit_control": "Enable Site Limit Control",
-          "sleep_after_write": "Inverter Command Delay (seconds)"
+          "adv_site_limit_control": "Enable Site Limit Control"
         },
         "description": "Warning: These options can violate utility agreements, alter your utility billing, may require special equipment, and overwrite provisioning by SolarEdge or your installer. Use at your own risk!"
       },

--- a/custom_components/solaredge_modbus_multi/translations/fr.json
+++ b/custom_components/solaredge_modbus_multi/translations/fr.json
@@ -36,15 +36,15 @@
           "detect_meters": "Auto-détecter les capteurs",
           "detect_batteries": "Auto-détecter les batteries",
           "detect_extras": "Détection automatique des entités supplémentaires",
-          "advanced_power_control": "Options de contrôle de l'alimentation"
+          "advanced_power_control": "Options de contrôle de l'alimentation",
+          "sleep_after_write": "Délai de commande de l'onduleur (en secondes)"
         }
       },
       "adv_pwr_ctl": {
         "title": "Options de contrôle de l'alimentation",
         "data": {
           "adv_storage_control": "Activer le contrôle du stockage",
-          "adv_site_limit_control": "Activer le contrôle des limites du site",
-          "sleep_after_write": "Délai de commande de l'onduleur (en secondes)"
+          "adv_site_limit_control": "Activer le contrôle des limites du site"
         },
         "description": "Avertissement : Ces options peuvent enfreindre l'accord d'utilisation, modifier la facturation de vos services, nécessiter un équipement spécial et écraser le provisionnement par SolarEdge ou votre installateur. À utiliser à vos risques et périls!"
       },

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -36,15 +36,15 @@
           "detect_meters": "Automatisk oppdagelse av målere",
           "detect_batteries": "Automatisk gjenkjenning av batterier",
           "detect_extras": "Automatisk oppdage flere enheter",
-          "advanced_power_control": "Avansert strømkontroll"
+          "advanced_power_control": "Avansert strømkontroll",
+          "sleep_after_write": "Inverter Command Delay (sekunder)"
         }
       },
       "adv_pwr_ctl": {
         "title": "Strømkontrollalternativer",
         "data": {
           "adv_storage_control": "Aktiver lagringskontroll",
-          "adv_site_limit_control": "Aktiver Site Limit Control",
-          "sleep_after_write": "Inverter Command Delay (sekunder)"
+          "adv_site_limit_control": "Aktiver Site Limit Control"
         },
         "description": "Advarsel: Disse alternativene kan bryte forsyningsavtaler, endre forbruksfaktureringen, kan kreve spesialutstyr og overskrive klargjøring av SolarEdge eller installatøren. Bruk på eget ansvar!"
       },

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -36,15 +36,15 @@
           "detect_meters": "Meters automatisch detecteren",
           "detect_batteries": "Batterijen automatisch detecteren",
           "detect_extras": "Automatische detectie van aanvullende entiteiten",
-          "advanced_power_control": "Geavanceerde stroomregeling"
+          "advanced_power_control": "Geavanceerde stroomregeling",
+          "sleep_after_write": "Omvormer commando vertraging (seconden)"
         }
       },
       "adv_pwr_ctl": {
         "title": "Opties voor stroomregeling",
         "data": {
           "adv_storage_control": "Opslagbeheer inschakelen",
-          "adv_site_limit_control": "Beheer van sitelimiet inschakelen",
-          "sleep_after_write": "Omvormer commando vertraging (seconden)"
+          "adv_site_limit_control": "Beheer van sitelimiet inschakelen"
         },
         "description": "Waarschuwing: deze opties kunnen in strijd zijn met nutsvoorzieningen, de facturering van uw nutsbedrijf wijzigen, mogelijk speciale apparatuur vereisen en de voorzieningen door SolarEdge of uw installateur overschrijven. Gebruik op eigen risico!"
       },

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -36,15 +36,15 @@
           "detect_meters": "Automatycznie wykryj liczniki",
           "detect_batteries": "Automatycznie wykryj baterie",
           "detect_extras": "Automatycznie wykrywaj dodatkowe elementy",
-          "advanced_power_control": "Zaawansowana kontrola mocy"
+          "advanced_power_control": "Zaawansowana kontrola mocy",
+          "sleep_after_write": "Opóźnienie polecenia falownika (sekundy)"
         }
       },
       "adv_pwr_ctl": {
         "title": "Opcje sterowania zasilaniem",
         "data": {
           "adv_storage_control": "Włącz kontrolę pamięci",
-          "adv_site_limit_control": "Włącz kontrolę limitu witryny",
-          "sleep_after_write": "Opóźnienie polecenia falownika (sekundy)"
+          "adv_site_limit_control": "Włącz kontrolę limitu witryny"
         },
         "description": "Ostrzeżenie: opcje te mogą naruszać umowy za media, zmieniać rozliczenia za media, mogą wymagać specjalnego sprzętu i nadpisać udostępnianie przez SolarEdge lub instalatora. Używaj na własne ryzyko!"
       },


### PR DESCRIPTION
Move inverter command delay to top level since this can now also apply to Auto-Detect Additional Entities even when Power Control Options is disabled.