### PR TITLE
Pymodbus constants from enum.Enum

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -724,7 +724,7 @@ class SolarEdgeInverter:
             )
 
             decoder = BinaryPayloadDecoder.fromRegisters(
-                inverter_data.registers, byteorder=Endian.Big
+                inverter_data.registers, byteorder=Endian.BIG
             )
 
             self.decoded_common = OrderedDict(
@@ -782,7 +782,7 @@ class SolarEdgeInverter:
             )
 
             decoder = BinaryPayloadDecoder.fromRegisters(
-                mmppt_common.registers, byteorder=Endian.Big
+                mmppt_common.registers, byteorder=Endian.BIG
             )
 
             self.decoded_mmppt = OrderedDict(
@@ -846,7 +846,7 @@ class SolarEdgeInverter:
             )
 
             decoder = BinaryPayloadDecoder.fromRegisters(
-                inverter_data.registers, byteorder=Endian.Big
+                inverter_data.registers, byteorder=Endian.BIG
             )
 
             self.decoded_model = OrderedDict(
@@ -925,7 +925,7 @@ class SolarEdgeInverter:
                 )
 
                 decoder = BinaryPayloadDecoder.fromRegisters(
-                    inverter_data.registers, byteorder=Endian.Big
+                    inverter_data.registers, byteorder=Endian.BIG
                 )
 
                 if self.decoded_mmppt["mmppt_Units"] in [2, 3]:
@@ -1011,8 +1011,8 @@ class SolarEdgeInverter:
 
                 decoder = BinaryPayloadDecoder.fromRegisters(
                     inverter_data.registers,
-                    byteorder=Endian.Big,
-                    wordorder=Endian.Little,
+                    byteorder=Endian.BIG,
+                    wordorder=Endian.LITTLE,
                 )
 
                 self.decoded_model.update(
@@ -1051,8 +1051,8 @@ class SolarEdgeInverter:
 
                 decoder = BinaryPayloadDecoder.fromRegisters(
                     inverter_data.registers,
-                    byteorder=Endian.Big,
-                    wordorder=Endian.Little,
+                    byteorder=Endian.BIG,
+                    wordorder=Endian.LITTLE,
                 )
 
                 self.decoded_model.update(
@@ -1091,8 +1091,8 @@ class SolarEdgeInverter:
 
                 decoder = BinaryPayloadDecoder.fromRegisters(
                     inverter_data.registers,
-                    byteorder=Endian.Big,
-                    wordorder=Endian.Little,
+                    byteorder=Endian.BIG,
+                    wordorder=Endian.LITTLE,
                 )
 
                 self.decoded_model.update(
@@ -1129,8 +1129,8 @@ class SolarEdgeInverter:
 
                 decoder = BinaryPayloadDecoder.fromRegisters(
                     inverter_data.registers,
-                    byteorder=Endian.Big,
-                    wordorder=Endian.Little,
+                    byteorder=Endian.BIG,
+                    wordorder=Endian.LITTLE,
                 )
 
                 self.decoded_model.update(
@@ -1181,8 +1181,8 @@ class SolarEdgeInverter:
 
                 decoder = BinaryPayloadDecoder.fromRegisters(
                     inverter_data.registers,
-                    byteorder=Endian.Big,
-                    wordorder=Endian.Little,
+                    byteorder=Endian.BIG,
+                    wordorder=Endian.LITTLE,
                 )
 
                 self.decoded_storage_control = OrderedDict(
@@ -1299,7 +1299,7 @@ class SolarEdgeMeter:
                 raise ModbusReadError(meter_info)
 
             decoder = BinaryPayloadDecoder.fromRegisters(
-                meter_info.registers, byteorder=Endian.Big
+                meter_info.registers, byteorder=Endian.BIG
             )
             self.decoded_common = OrderedDict(
                 [
@@ -1364,7 +1364,7 @@ class SolarEdgeMeter:
             )
 
             decoder = BinaryPayloadDecoder.fromRegisters(
-                meter_data.registers, byteorder=Endian.Big
+                meter_data.registers, byteorder=Endian.BIG
             )
 
             self.decoded_model = OrderedDict(
@@ -1524,8 +1524,8 @@ class SolarEdgeBattery:
 
             decoder = BinaryPayloadDecoder.fromRegisters(
                 battery_info.registers,
-                byteorder=Endian.Big,
-                wordorder=Endian.Little,
+                byteorder=Endian.BIG,
+                wordorder=Endian.LITTLE,
             )
             self.decoded_common = OrderedDict(
                 [
@@ -1620,8 +1620,8 @@ class SolarEdgeBattery:
 
             decoder = BinaryPayloadDecoder.fromRegisters(
                 battery_data.registers,
-                byteorder=Endian.Big,
-                wordorder=Endian.Little,
+                byteorder=Endian.BIG,
+                wordorder=Endian.LITTLE,
             )
 
             self.decoded_model = OrderedDict(

--- a/custom_components/solaredge_modbus_multi/number.py
+++ b/custom_components/solaredge_modbus_multi/number.py
@@ -164,7 +164,7 @@ class StorageACChargeLimit(SolarEdgeNumberBase):
 
     async def async_set_native_value(self, value: float) -> None:
         _LOGGER.debug(f"set {self.unique_id} to {value}")
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=Endian.LITTLE)
         builder.add_32bit_float(float(value))
         await self._platform.write_registers(
             address=57350, payload=builder.to_registers()
@@ -208,7 +208,7 @@ class StorageBackupReserve(SolarEdgeNumberBase):
 
     async def async_set_native_value(self, value: float) -> None:
         _LOGGER.debug(f"set {self.unique_id} to {value}")
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=Endian.LITTLE)
         builder.add_32bit_float(float(value))
         await self._platform.write_registers(
             address=57352, payload=builder.to_registers()
@@ -259,7 +259,7 @@ class StorageCommandTimeout(SolarEdgeNumberBase):
 
     async def async_set_native_value(self, value: int) -> None:
         _LOGGER.debug(f"set {self.unique_id} to {value}")
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=Endian.LITTLE)
         builder.add_32bit_uint(int(value))
         await self._platform.write_registers(
             address=57355, payload=builder.to_registers()
@@ -310,7 +310,7 @@ class StorageChargeLimit(SolarEdgeNumberBase):
 
     async def async_set_native_value(self, value: float) -> None:
         _LOGGER.debug(f"set {self.unique_id} to {value}")
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=Endian.LITTLE)
         builder.add_32bit_float(float(value))
         await self._platform.write_registers(
             address=57358, payload=builder.to_registers()
@@ -361,7 +361,7 @@ class StorageDischargeLimit(SolarEdgeNumberBase):
 
     async def async_set_native_value(self, value: float) -> None:
         _LOGGER.debug(f"set {self.unique_id} to {value}")
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=Endian.LITTLE)
         builder.add_32bit_float(float(value))
         await self._platform.write_registers(
             address=57360, payload=builder.to_registers()
@@ -415,7 +415,7 @@ class SolarEdgeSiteLimit(SolarEdgeNumberBase):
 
     async def async_set_native_value(self, value: float) -> None:
         _LOGGER.debug(f"set {self.unique_id} to {value}")
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=Endian.LITTLE)
         builder.add_32bit_float(float(value))
         await self._platform.write_registers(
             address=57346, payload=builder.to_registers()
@@ -472,7 +472,7 @@ class SolarEdgeExternalProductionMax(SolarEdgeNumberBase):
 
     async def async_set_native_value(self, value: float) -> None:
         _LOGGER.debug(f"set {self.unique_id} to {value}")
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=Endian.LITTLE)
         builder.add_32bit_float(float(value))
         await self._platform.write_registers(
             address=57362, payload=builder.to_registers()
@@ -525,7 +525,7 @@ class SolarEdgeActivePowerLimitSet(SolarEdgeNumberBase):
 
     async def async_set_native_value(self, value: float) -> None:
         _LOGGER.debug(f"set {self.unique_id} to {value}")
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=Endian.LITTLE)
         builder.add_16bit_uint(int(value))
         await self._platform.write_registers(
             address=61441, payload=builder.to_registers()
@@ -579,7 +579,7 @@ class SolarEdgeCosPhiSet(SolarEdgeNumberBase):
 
     async def async_set_native_value(self, value: float) -> None:
         _LOGGER.debug(f"set {self.unique_id} to {value}")
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=Endian.LITTLE)
         builder.add_32bit_float(float(value))
         await self._platform.write_registers(
             address=61442, payload=builder.to_registers()

--- a/custom_components/solaredge_modbus_multi/switch.py
+++ b/custom_components/solaredge_modbus_multi/switch.py
@@ -214,7 +214,7 @@ class SolarEdgeGridControl(SolarEdgeSwitchBase):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         _LOGGER.debug(f"set {self.unique_id} to 0x1")
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=Endian.LITTLE)
         builder.add_32bit_int(0x1)
         await self._platform.write_registers(
             address=61762, payload=builder.to_registers()
@@ -223,7 +223,7 @@ class SolarEdgeGridControl(SolarEdgeSwitchBase):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         _LOGGER.debug(f"set {self.unique_id} to 0x0")
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=Endian.Little)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=Endian.LITTLE)
         builder.add_32bit_int(0x0)
         await self._platform.write_registers(
             address=61762, payload=builder.to_registers()


### PR DESCRIPTION
Static classes from pymodbus `constants` module are now inheriting from`enum.Enum` and using `UPPER_CASE` naming scheme.

Change is required for Pymodbus 3.5.1 used in Home Assistant 2023.9.1

Home Assistant 2023.9.0 uses Pymodbus 3.4.1