### PR TITLE
Pymodbus 3.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ After rebooting Home Assistant, this integration can be configured through the i
 ### Required Versions
 * Home Assistant 2023.9.1 or newer
 * Python 3.11 or newer
-* pymodbus 3.5.1 or newer
+* pymodbus 3.5.2 or newer
 
 ## Specifications
 [WillCodeForCats/solaredge-modbus-multi/tree/main/doc](https://github.com/WillCodeForCats/solaredge-modbus-multi/tree/main/doc)

--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/WillCodeForCats/solaredge-modbus-multi/issues",
   "loggers": ["custom_components.solaredge_modbus_multi"],
-  "requirements": ["pymodbus==3.5.1"],
+  "requirements": ["pymodbus==3.5.2"],
   "version": "2.4.5"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymodbus==3.5.1
+pymodbus==3.5.2


### PR DESCRIPTION
Bump deps Pymodbus 3.5.2 to match HA 2023.9.2

Do not see any changes that would break backwards compat with 2023.9.1 so not changing HA min version.