### PR TITLE
Use minimum instead of pinning pymodbus version

### DIFF
--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/WillCodeForCats/solaredge-modbus-multi/issues",
   "loggers": ["custom_components.solaredge_modbus_multi"],
-  "requirements": ["pymodbus==3.5.2"],
+  "requirements": ["pymodbus>=3.5.2"],
   "version": "2.4.6-pre.3"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymodbus==3.5.2
+pymodbus>=3.5.2


### PR DESCRIPTION
Creating a new release every time pymodbus updates in HA core is a lot of extra work if it's not an update that has any breaking API changes.