### PR TITLE
Bump min pymodbus version to 3.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ After rebooting Home Assistant, this integration can be configured through the i
 ### Required Versions
 * Home Assistant 2023.9.1 or newer
 * Python 3.11 or newer
-* pymodbus 3.5.1 or newer
+* pymodbus 3.5.4 or newer
 
 ## Specifications
 [WillCodeForCats/solaredge-modbus-multi/tree/main/doc](https://github.com/WillCodeForCats/solaredge-modbus-multi/tree/main/doc)

--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/WillCodeForCats/solaredge-modbus-multi/issues",
   "loggers": ["custom_components.solaredge_modbus_multi"],
-  "requirements": ["pymodbus>=3.5.1"],
+  "requirements": ["pymodbus>=3.5.4"],
   "version": "2.4.6"
 }

--- a/info.md
+++ b/info.md
@@ -22,4 +22,4 @@ Read more on the wiki: [WillCodeForCats/solaredge-modbus-multi/wiki](https://git
 * Supports status and error reporting sensors.
 * User friendly configuration through Config Flow.
 
-Requires Home Assistant 2023.9.1 and newer with pymodbus 3.5.1 and newer.
+Requires Home Assistant 2023.9.1 and newer with pymodbus 3.5.4 and newer.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymodbus>=3.5.1
+pymodbus>=3.5.4


### PR DESCRIPTION
pymodbus 3.5.3 contains a fix for an option we use in pymodbus-dev/pymodbus/pull/1795