### PR TITLE
Site limit values less than 0 display as 0 instead of unavailable

### DIFF
--- a/custom_components/solaredge_modbus_multi/number.py
+++ b/custom_components/solaredge_modbus_multi/number.py
@@ -419,10 +419,8 @@ class SolarEdgeSiteLimit(SolarEdgeNumberBase):
     @property
     def available(self) -> bool:
         try:
-            if (
-                float_to_hex(self._platform.decoded_model["E_Site_Limit"])
-                == hex(SunSpecNotImpl.FLOAT32)
-                or self._platform.decoded_model["E_Site_Limit"] < 0
+            if float_to_hex(self._platform.decoded_model["E_Site_Limit"]) == hex(
+                SunSpecNotImpl.FLOAT32
             ):
                 return False
 
@@ -437,6 +435,9 @@ class SolarEdgeSiteLimit(SolarEdgeNumberBase):
 
     @property
     def native_value(self) -> int:
+        if self._platform.decoded_model["E_Site_Limit"] < 0:
+            return 0
+
         return int(self._platform.decoded_model["E_Site_Limit"])
 
     async def async_set_native_value(self, value: float) -> None:


### PR DESCRIPTION
In issue #461 site limit is being reported as a negative number. I'm not sure what the reason behind this is, but this PR overrides values < 0 as zero and make the entity available.