### PR TITLE
Battery charge/discharge power as sensors

### DIFF
--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -188,6 +188,18 @@ async def async_setup_entry(
         )
         entities.append(SolarEdgeBatteryMaxEnergy(battery, config_entry, coordinator))
         entities.append(
+            SolarEdgeBatteryMaxChargePower(battery, config_entry, coordinator)
+        )
+        entities.append(
+            SolarEdgeBatteryMaxDischargePower(battery, config_entry, coordinator)
+        )
+        entities.append(
+            SolarEdgeBatteryMaxChargePeakPower(battery, config_entry, coordinator)
+        )
+        entities.append(
+            SolarEdgeBatteryMaxDischargePeakPower(battery, config_entry, coordinator)
+        )
+        entities.append(
             SolarEdgeBatteryAvailableEnergy(battery, config_entry, coordinator)
         )
         entities.append(SolarEdgeBatterySOH(battery, config_entry, coordinator))
@@ -256,42 +268,6 @@ class SolarEdgeDevice(SolarEdgeSensorBase):
         attrs = {}
 
         try:
-            if (
-                float_to_hex(self._platform.decoded_common["B_MaxChargePeakPower"])
-                != hex(SunSpecNotImpl.FLOAT32)
-                and self._platform.decoded_common["B_MaxChargePeakPower"] > 0
-            ):
-                attrs["batt_charge_peak"] = self._platform.decoded_common[
-                    "B_MaxChargePeakPower"
-                ]
-
-            if (
-                float_to_hex(self._platform.decoded_common["B_MaxDischargePeakPower"])
-                != hex(SunSpecNotImpl.FLOAT32)
-                and self._platform.decoded_common["B_MaxDischargePeakPower"] > 0
-            ):
-                attrs["batt_discharge_peak"] = self._platform.decoded_common[
-                    "B_MaxDischargePeakPower"
-                ]
-
-            if (
-                float_to_hex(self._platform.decoded_common["B_MaxChargePower"])
-                != hex(SunSpecNotImpl.FLOAT32)
-                and self._platform.decoded_common["B_MaxChargePower"] > 0
-            ):
-                attrs["batt_max_charge"] = self._platform.decoded_common[
-                    "B_MaxChargePower"
-                ]
-
-            if (
-                float_to_hex(self._platform.decoded_common["B_MaxDischargePower"])
-                != hex(SunSpecNotImpl.FLOAT32)
-                and self._platform.decoded_common["B_MaxDischargePower"] > 0
-            ):
-                attrs["batt_max_discharge"] = self._platform.decoded_common[
-                    "B_MaxDischargePower"
-                ]
-
             if (
                 float_to_hex(self._platform.decoded_common["B_RatedEnergy"])
                 != hex(SunSpecNotImpl.FLOAT32)
@@ -2004,6 +1980,142 @@ class SolarEdgeBatteryMaxEnergy(SolarEdgeSensorBase):
 
         else:
             return self._platform.decoded_model["B_Energy_Max"] * 0.001
+
+
+class SolarEdgeBatteryMaxChargePower(SolarEdgeSensorBase):
+    device_class = SensorDeviceClass.POWER
+    state_class = SensorStateClass.MEASUREMENT
+    native_unit_of_measurement = UnitOfPower.WATT
+    entity_category = EntityCategory.DIAGNOSTIC
+    suggested_display_precision = 0
+
+    def __init__(self, platform, config_entry, coordinator):
+        super().__init__(platform, config_entry, coordinator)
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_max_charge_power"
+
+    @property
+    def name(self) -> str:
+        return "Charge Power"
+
+    @property
+    def available(self):
+        if (
+            float_to_hex(self._platform.decoded_model["B_MaxChargePower"])
+            == hex(SunSpecNotImpl.FLOAT32)
+            or self._platform.decoded_model["B_MaxChargePower"] < 0
+        ):
+            return False
+
+        return super().available
+
+    @property
+    def native_value(self):
+        return self._platform.decoded_model["B_MaxChargePower"]
+
+
+class SolarEdgeBatteryMaxChargePeakPower(SolarEdgeSensorBase):
+    device_class = SensorDeviceClass.POWER
+    state_class = SensorStateClass.MEASUREMENT
+    native_unit_of_measurement = UnitOfPower.WATT
+    entity_category = EntityCategory.DIAGNOSTIC
+    suggested_display_precision = 0
+
+    def __init__(self, platform, config_entry, coordinator):
+        super().__init__(platform, config_entry, coordinator)
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_max_charge_peak_power"
+
+    @property
+    def name(self) -> str:
+        return "Charge Peak Power"
+
+    @property
+    def available(self):
+        if (
+            float_to_hex(self._platform.decoded_model["B_MaxChargePeakPower"])
+            == hex(SunSpecNotImpl.FLOAT32)
+            or self._platform.decoded_model["B_MaxChargePeakPower"] < 0
+        ):
+            return False
+
+        return super().available
+
+    @property
+    def native_value(self):
+        return self._platform.decoded_model["B_MaxChargePeakPower"]
+
+
+class SolarEdgeBatteryMaxDischargePower(SolarEdgeSensorBase):
+    device_class = SensorDeviceClass.POWER
+    state_class = SensorStateClass.MEASUREMENT
+    native_unit_of_measurement = UnitOfPower.WATT
+    entity_category = EntityCategory.DIAGNOSTIC
+    suggested_display_precision = 0
+
+    def __init__(self, platform, config_entry, coordinator):
+        super().__init__(platform, config_entry, coordinator)
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_max_discharge_power"
+
+    @property
+    def name(self) -> str:
+        return "Discharge Power"
+
+    @property
+    def available(self):
+        if (
+            float_to_hex(self._platform.decoded_model["B_MaxDischargePower"])
+            == hex(SunSpecNotImpl.FLOAT32)
+            or self._platform.decoded_model["B_MaxDischargePower"] < 0
+        ):
+            return False
+
+        return super().available
+
+    @property
+    def native_value(self):
+        return self._platform.decoded_model["B_MaxDischargePower"]
+
+
+class SolarEdgeBatteryMaxDischargePeakPower(SolarEdgeSensorBase):
+    device_class = SensorDeviceClass.POWER
+    state_class = SensorStateClass.MEASUREMENT
+    native_unit_of_measurement = UnitOfPower.WATT
+    entity_category = EntityCategory.DIAGNOSTIC
+    suggested_display_precision = 0
+
+    def __init__(self, platform, config_entry, coordinator):
+        super().__init__(platform, config_entry, coordinator)
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_max_discharge_peak_power"
+
+    @property
+    def name(self) -> str:
+        return "Discharge Peak Power"
+
+    @property
+    def available(self):
+        if (
+            float_to_hex(self._platform.decoded_model["B_MaxDischargePeakPower"])
+            == hex(SunSpecNotImpl.FLOAT32)
+            or self._platform.decoded_model["B_MaxDischargePeakPower"] < 0
+        ):
+            return False
+
+        return super().available
+
+    @property
+    def native_value(self):
+        return self._platform.decoded_model["B_MaxDischargePeakPower"]
 
 
 class SolarEdgeBatteryAvailableEnergy(SolarEdgeSensorBase):

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1998,7 +1998,7 @@ class SolarEdgeBatteryMaxChargePower(SolarEdgeSensorBase):
 
     @property
     def name(self) -> str:
-        return "Charge Power"
+        return "Max Charge Power"
 
     @property
     def available(self):
@@ -2032,7 +2032,7 @@ class SolarEdgeBatteryMaxChargePeakPower(SolarEdgeSensorBase):
 
     @property
     def name(self) -> str:
-        return "Charge Peak Power"
+        return "Peak Charge Power"
 
     @property
     def available(self):
@@ -2066,7 +2066,7 @@ class SolarEdgeBatteryMaxDischargePower(SolarEdgeSensorBase):
 
     @property
     def name(self) -> str:
-        return "Discharge Power"
+        return "Max Discharge Power"
 
     @property
     def available(self):
@@ -2100,7 +2100,7 @@ class SolarEdgeBatteryMaxDischargePeakPower(SolarEdgeSensorBase):
 
     @property
     def name(self) -> str:
-        return "Discharge Peak Power"
+        return "Peak Discharge Power"
 
     @property
     def available(self):

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1982,16 +1982,15 @@ class SolarEdgeBatteryMaxEnergy(SolarEdgeSensorBase):
             return self._platform.decoded_model["B_Energy_Max"] * 0.001
 
 
-class SolarEdgeBatteryMaxChargePower(SolarEdgeSensorBase):
+class SolarEdgeBatteryPowerBase(SolarEdgeSensorBase):
     device_class = SensorDeviceClass.POWER
     state_class = SensorStateClass.MEASUREMENT
     native_unit_of_measurement = UnitOfPower.WATT
     entity_category = EntityCategory.DIAGNOSTIC
     suggested_display_precision = 0
 
-    def __init__(self, platform, config_entry, coordinator):
-        super().__init__(platform, config_entry, coordinator)
 
+class SolarEdgeBatteryMaxChargePower(SolarEdgeBatteryPowerBase):
     @property
     def unique_id(self) -> str:
         return f"{self._platform.uid_base}_max_charge_power"
@@ -2016,16 +2015,7 @@ class SolarEdgeBatteryMaxChargePower(SolarEdgeSensorBase):
         return self._platform.decoded_model["B_MaxChargePower"]
 
 
-class SolarEdgeBatteryMaxChargePeakPower(SolarEdgeSensorBase):
-    device_class = SensorDeviceClass.POWER
-    state_class = SensorStateClass.MEASUREMENT
-    native_unit_of_measurement = UnitOfPower.WATT
-    entity_category = EntityCategory.DIAGNOSTIC
-    suggested_display_precision = 0
-
-    def __init__(self, platform, config_entry, coordinator):
-        super().__init__(platform, config_entry, coordinator)
-
+class SolarEdgeBatteryMaxChargePeakPower(SolarEdgeBatteryPowerBase):
     @property
     def unique_id(self) -> str:
         return f"{self._platform.uid_base}_max_charge_peak_power"
@@ -2050,16 +2040,7 @@ class SolarEdgeBatteryMaxChargePeakPower(SolarEdgeSensorBase):
         return self._platform.decoded_model["B_MaxChargePeakPower"]
 
 
-class SolarEdgeBatteryMaxDischargePower(SolarEdgeSensorBase):
-    device_class = SensorDeviceClass.POWER
-    state_class = SensorStateClass.MEASUREMENT
-    native_unit_of_measurement = UnitOfPower.WATT
-    entity_category = EntityCategory.DIAGNOSTIC
-    suggested_display_precision = 0
-
-    def __init__(self, platform, config_entry, coordinator):
-        super().__init__(platform, config_entry, coordinator)
-
+class SolarEdgeBatteryMaxDischargePower(SolarEdgeBatteryPowerBase):
     @property
     def unique_id(self) -> str:
         return f"{self._platform.uid_base}_max_discharge_power"
@@ -2084,16 +2065,7 @@ class SolarEdgeBatteryMaxDischargePower(SolarEdgeSensorBase):
         return self._platform.decoded_model["B_MaxDischargePower"]
 
 
-class SolarEdgeBatteryMaxDischargePeakPower(SolarEdgeSensorBase):
-    device_class = SensorDeviceClass.POWER
-    state_class = SensorStateClass.MEASUREMENT
-    native_unit_of_measurement = UnitOfPower.WATT
-    entity_category = EntityCategory.DIAGNOSTIC
-    suggested_display_precision = 0
-
-    def __init__(self, platform, config_entry, coordinator):
-        super().__init__(platform, config_entry, coordinator)
-
+class SolarEdgeBatteryMaxDischargePeakPower(SolarEdgeBatteryPowerBase):
     @property
     def unique_id(self) -> str:
         return f"{self._platform.uid_base}_max_discharge_peak_power"


### PR DESCRIPTION
This PR changes the following battery device attributes into sensors:

* batt_charge_peak
* batt_discharge_peak
* batt_max_charge
* batt_max_discharge

These are listed as "nameplate" values in specs which implies static information, but it was bought to my attention that these values can actually change. Values that are dynamic in their own right should be implemented as sensors.