### PR TITLE
Rename grid control switch to match binary sensor

### DIFF
--- a/custom_components/solaredge_modbus_multi/switch.py
+++ b/custom_components/solaredge_modbus_multi/switch.py
@@ -190,11 +190,11 @@ class SolarEdgeGridControl(SolarEdgeSwitchBase):
 
     @property
     def unique_id(self) -> str:
-        return f"{self._platform.uid_base}_grid_control"
+        return f"{self._platform.uid_base}_adv_pwr_ctrl"
 
     @property
     def name(self) -> str:
-        return "Grid Control"
+        return "Advanced Power Control"
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
Rename grid control switch to match binary sensor