### PR TITLE
Add Current Limit number entity

### DIFF
--- a/custom_components/solaredge_modbus_multi/number.py
+++ b/custom_components/solaredge_modbus_multi/number.py
@@ -4,7 +4,13 @@ import logging
 
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfPower, UnitOfTime
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfElectricCurrent,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -62,6 +68,7 @@ async def async_setup_entry(
     if hub.option_detect_extras and inverter.advanced_power_control:
         for inverter in hub.inverters:
             entities.append(SolarEdgePowerReduce(inverter, config_entry, coordinator))
+            entities.append(SolarEdgeCurrentLimit(inverter, config_entry, coordinator))
 
     if entities:
         async_add_entities(entities)
@@ -663,5 +670,55 @@ class SolarEdgePowerReduce(SolarEdgeNumberBase):
         builder.add_32bit_float(float(value))
         await self._platform.write_registers(
             address=61760, payload=builder.to_registers()
+        )
+        await self.async_update()
+
+
+class SolarEdgeCurrentLimit(SolarEdgeNumberBase):
+    """Limits the inverter's maximum output current."""
+
+    native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+    native_min_value = 0
+    native_max_value = 256
+    icon = "mdi:current-ac"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_max_current"
+
+    @property
+    def name(self) -> str:
+        return "Current Limit"
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        return False
+
+    @property
+    def available(self) -> bool:
+        try:
+            if (
+                float_to_hex(self._platform.decoded_model["MaxCurrent"])
+                == hex(SunSpecNotImpl.FLOAT32)
+                or self._platform.decoded_model["MaxCurrent"] > 256
+                or self._platform.decoded_model["MaxCurrent"] < 0
+            ):
+                return False
+
+            return super().available
+
+        except (TypeError, KeyError):
+            return False
+
+    @property
+    def native_value(self) -> int:
+        return round(self._platform.decoded_model["MaxCurrent"], 0)
+
+    async def async_set_native_value(self, value: float) -> None:
+        _LOGGER.debug(f"set {self.unique_id} to {value}")
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=Endian.LITTLE)
+        builder.add_32bit_float(float(value))
+        await self._platform.write_registers(
+            address=61838, payload=builder.to_registers()
         )
         await self.async_update()


### PR DESCRIPTION
Add Current Limit number entity. Limits the inverter’s maximum output current. The current limit can be set to any value between 0 and inverter max AC current (values higher will be ignored).