### PR TITLE
Disconnect and retry on timeouts

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -225,8 +225,7 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
         attempt = 1
         while True:
             try:
-                async with asyncio.timeout(self._hub.coordinator_timeout):
-                    return await self._hub.async_refresh_modbus_data()
+                return await self._hub.async_refresh_modbus_data()
             except Exception as ex:
                 if not isinstance(ex, ex_type):
                     raise ex


### PR DESCRIPTION
Disconnect and retry on timeouts, with timeout limit.

Observed a case where inverter may be slow to respond causing timeouts. Forcing a disconnect within the retry cycle might help.