### PR TITLE
Smaller reads in power control block

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1029,7 +1029,7 @@ class SolarEdgeInverter:
         ):
             try:
                 inverter_data = await self.hub.modbus_read_holding_registers(
-                    unit=self.inverter_unit_id, address=61696, rcount=86
+                    unit=self.inverter_unit_id, address=61696, rcount=6
                 )
 
                 decoder = BinaryPayloadDecoder.fromRegisters(
@@ -1045,52 +1045,12 @@ class SolarEdgeInverter:
                             ("RestorePwrCtlDefaults", decoder.decode_16bit_int()),
                             ("PwrFrqDeratingConfig", decoder.decode_32bit_int()),
                             ("ReactivePwrConfig", decoder.decode_32bit_int()),
-                            ("ReactPwrIterTime", decoder.decode_32bit_uint()),
-                            ("ActivePwrGrad", decoder.decode_32bit_int()),
-                            ("FixedCosPhiPhase", decoder.decode_32bit_float()),
-                            ("FixedReactPwr", decoder.decode_32bit_float()),
-                            ("ReactCosPhiVsPX_0", decoder.decode_32bit_float()),
-                            ("ReactCosPhiVsPX_1", decoder.decode_32bit_float()),
-                            ("ReactCosPhiVsPX_2", decoder.decode_32bit_float()),
-                            ("ReactCosPhiVsPX_3", decoder.decode_32bit_float()),
-                            ("ReactCosPhiVsPX_4", decoder.decode_32bit_float()),
-                            ("ReactCosPhiVsPX_5", decoder.decode_32bit_float()),
-                            ("ReactCosPhiVsPY_0", decoder.decode_32bit_float()),
-                            ("ReactCosPhiVsPY_1", decoder.decode_32bit_float()),
-                            ("ReactCosPhiVsPY_2", decoder.decode_32bit_float()),
-                            ("ReactCosPhiVsPY_3", decoder.decode_32bit_float()),
-                            ("ReactCosPhiVsPY_4", decoder.decode_32bit_float()),
-                            ("ReactCosPhiVsPY_5", decoder.decode_32bit_float()),
-                            ("ReactQVsVgX_0", decoder.decode_32bit_float()),
-                            ("ReactQVsVgX_1", decoder.decode_32bit_float()),
-                            ("ReactQVsVgX_2", decoder.decode_32bit_float()),
-                            ("ReactQVsVgX_3", decoder.decode_32bit_float()),
-                            ("ReactQVsVgX_4", decoder.decode_32bit_float()),
-                            ("ReactQVsVgX_5", decoder.decode_32bit_float()),
-                            ("ReactQVsVgY_0", decoder.decode_32bit_float()),
-                            ("ReactQVsVgY_1", decoder.decode_32bit_float()),
-                            ("ReactQVsVgY_2", decoder.decode_32bit_float()),
-                            ("ReactQVsVgY_3", decoder.decode_32bit_float()),
-                            ("ReactQVsVgY_4", decoder.decode_32bit_float()),
-                            ("ReactQVsVgY_5", decoder.decode_32bit_float()),
-                            ("FRT_KFactor", decoder.decode_32bit_float()),
-                            ("PowerReduce", decoder.decode_32bit_float()),
-                            ("AdvPwrCtrlEn", decoder.decode_32bit_int()),
-                            ("FrtEn", decoder.decode_32bit_int()),
-                            ("MaxWakeupFreq", decoder.decode_32bit_float()),
-                            ("MinWakeupFreq", decoder.decode_32bit_float()),
-                            ("MaxWakeupVg", decoder.decode_32bit_float()),
-                            ("MinWakeupVg", decoder.decode_32bit_float()),
-                            ("Vnom", decoder.decode_32bit_float()),
-                            ("Inom", decoder.decode_32bit_float()),
-                            ("PwrVsFreqX_0", decoder.decode_32bit_float()),
-                            ("PwrVsFreqX_1", decoder.decode_32bit_float()),
                         ]
                     )
                 )
 
                 inverter_data = await self.hub.modbus_read_holding_registers(
-                    unit=self.inverter_unit_id, address=61782, rcount=84
+                    unit=self.inverter_unit_id, address=61760, rcount=4
                 )
 
                 decoder = BinaryPayloadDecoder.fromRegisters(
@@ -1102,60 +1062,26 @@ class SolarEdgeInverter:
                 self.decoded_model.update(
                     OrderedDict(
                         [
-                            ("PwrVsFreqY_0", decoder.decode_32bit_float()),
-                            ("PwrVsFreqY_1", decoder.decode_32bit_float()),
-                            ("ResetFreq", decoder.decode_32bit_float()),
-                            ("MaxFreq", decoder.decode_32bit_float()),
-                            ("ReactQVsPX_0", decoder.decode_32bit_float()),
-                            ("ReactQVsPX_1", decoder.decode_32bit_float()),
-                            ("ReactQVsPX_2", decoder.decode_32bit_float()),
-                            ("ReactQVsPX_3", decoder.decode_32bit_float()),
-                            ("ReactQVsPX_4", decoder.decode_32bit_float()),
-                            ("ReactQVsPX_5", decoder.decode_32bit_float()),
-                            ("ReactQVsPY_0", decoder.decode_32bit_float()),
-                            ("ReactQVsPY_1", decoder.decode_32bit_float()),
-                            ("ReactQVsPY_2", decoder.decode_32bit_float()),
-                            ("ReactQVsPY_3", decoder.decode_32bit_float()),
-                            ("ReactQVsPY_4", decoder.decode_32bit_float()),
-                            ("ReactQVsPY_5", decoder.decode_32bit_float()),
-                            ("PwrFrqDeratingResetTime", decoder.decode_32bit_uint()),
-                            ("PwrFrqDeratingGradTime", decoder.decode_32bit_uint()),
-                            (
-                                "ReactCosPhiVsPVgLockInMax",
-                                decoder.decode_32bit_float(),
-                            ),
-                            (
-                                "ReactCosPhiVsPVgLockInMin",
-                                decoder.decode_32bit_float(),
-                            ),
-                            (
-                                "ReactCosPhiVsPVgLockOutMax",
-                                decoder.decode_32bit_float(),
-                            ),
-                            (
-                                "ReactCosPhiVsPVgLockOutMin",
-                                decoder.decode_32bit_float(),
-                            ),
-                            ("ReactQVsVgPLockInMax", decoder.decode_32bit_float()),
-                            ("ReactQVsVgPLockInMin", decoder.decode_32bit_float()),
-                            ("ReactQVsVgPLockOutMax", decoder.decode_32bit_float()),
-                            ("ReactQVsVgPLockOutMin", decoder.decode_32bit_float()),
-                            ("ReactQVsVgType", decoder.decode_32bit_uint()),
-                            ("PwrSoftStartTime", decoder.decode_32bit_uint()),
+                            ("PowerReduce", decoder.decode_32bit_float()),
+                            ("AdvPwrCtrlEn", decoder.decode_32bit_int()),
+                        ]
+                    )
+                )
+
+                inverter_data = await self.hub.modbus_read_holding_registers(
+                    unit=self.inverter_unit_id, address=61838, rcount=2
+                )
+
+                decoder = BinaryPayloadDecoder.fromRegisters(
+                    inverter_data.registers,
+                    byteorder=Endian.BIG,
+                    wordorder=Endian.LITTLE,
+                )
+
+                self.decoded_model.update(
+                    OrderedDict(
+                        [
                             ("MaxCurrent", decoder.decode_32bit_float()),
-                            ("PwrVsVgX_0", decoder.decode_32bit_float()),
-                            ("PwrVsVgX_1", decoder.decode_32bit_float()),
-                            ("PwrVsVgX_2", decoder.decode_32bit_float()),
-                            ("PwrVsVgX_3", decoder.decode_32bit_float()),
-                            ("PwrVsVgX_4", decoder.decode_32bit_float()),
-                            ("PwrVsVgX_5", decoder.decode_32bit_float()),
-                            ("PwrVsVgY_0", decoder.decode_32bit_float()),
-                            ("PwrVsVgY_1", decoder.decode_32bit_float()),
-                            ("PwrVsVgY_2", decoder.decode_32bit_float()),
-                            ("PwrVsVgY_3", decoder.decode_32bit_float()),
-                            ("PwrVsVgY_4", decoder.decode_32bit_float()),
-                            ("PwrVsVgY_5", decoder.decode_32bit_float()),
-                            ("DisconnectAtZeroPwrLim", decoder.decode_32bit_float()),
                         ]
                     )
                 )


### PR DESCRIPTION
Smaller reads in power control block. Trying this since it's the only major difference in reading between 2.4.9 and 2.4.10 with a reported timeout issue.