### PR TITLE
Remove keep modbus open requirement

### DIFF
--- a/custom_components/solaredge_modbus_multi/__init__.py
+++ b/custom_components/solaredge_modbus_multi/__init__.py
@@ -181,10 +181,6 @@ class SolarEdgeCoordinator(DataUpdateCoordinator):
         )
         self._hub = hub
 
-        if scan_interval < 10 and not self._hub.keep_modbus_open:
-            _LOGGER.warning("Polling frequency < 10, requiring keep modbus open.")
-            self._hub.keep_modbus_open = True
-
     async def _async_update_data(self):
         try:
             while self._hub.has_write:


### PR DESCRIPTION
Remove keep modbus open requirement for polling intervals less than 10 seconds.