### PR TITLE
Always read grid status

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1302,7 +1302,7 @@ class SolarEdgeInverter:
                 )
 
         """ Grid On/Off Status """
-        if self.hub.option_detect_extras is True and self._grid_status is not False:
+        if self._grid_status is not False:
             try:
                 inverter_data = await self.hub.modbus_read_holding_registers(
                     unit=self.inverter_unit_id, address=40113, rcount=2


### PR DESCRIPTION
Always read grid status. This can't be combined under "extras" because inverters that have the no response issue for power control registers can support this location.