### PR TITLE
Disable option Auto-Detect Additional Entities by default

### DIFF
--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -89,7 +89,7 @@ class ConfDefaultFlag(IntEnum):
 
     DETECT_METERS = 1
     DETECT_BATTERIES = 0
-    DETECT_EXTRAS = 1
+    DETECT_EXTRAS = 0
     KEEP_MODBUS_OPEN = 0
     ADV_PWR_CONTROL = 0
     ADV_STORAGE_CONTROL = 0


### PR DESCRIPTION
Multiple reports that SolarEdge has changed something in recent firmware that causes the inverter to hang with no response when requesting registers that it doesn't support. The old behavior would return an modbus error that we could detect.

Because this is becoming a common complaint and the problem is with SolarEdge firmware that I can't fix, consider changing the integration default for Auto-Detect Additional Entities to default disabled. This will only affect new hubs. Existing setups will need a different solution to be more user friendly.

<img width="416" alt="Screenshot 2024-08-28 at 10 28 36" src="https://github.com/user-attachments/assets/66e8801b-8828-457a-970f-707a5b0cfd8e">
