### PR TITLE
Use UnitOfReactivePower class enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ After rebooting Home Assistant, this integration can be configured through the i
 [WillCodeForCats/solaredge-modbus-multi/wiki](https://github.com/WillCodeForCats/solaredge-modbus-multi/wiki)
 
 ### Required Versions
-* Home Assistant 2024.4.0 or newer
+* Home Assistant 2024.9.0 or newer
 * Python 3.11 or newer
 * pymodbus 3.6.6 or newer
 

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -11,13 +11,13 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
-    POWER_VOLT_AMPERE_REACTIVE,
     UnitOfApparentPower,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
     UnitOfFrequency,
     UnitOfPower,
+    UnitOfReactivePower,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -702,7 +702,7 @@ class ACVoltAmp(SolarEdgeSensorBase):
 class ACVoltAmpReactive(SolarEdgeSensorBase):
     device_class = SensorDeviceClass.REACTIVE_POWER
     state_class = SensorStateClass.MEASUREMENT
-    native_unit_of_measurement = POWER_VOLT_AMPERE_REACTIVE
+    native_unit_of_measurement = UnitOfReactivePower.VOLT_AMPERE_REACTIVE
 
     def __init__(self, platform, config_entry, coordinator, phase: str = None):
         super().__init__(platform, config_entry, coordinator)

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "SolarEdge Modbus Multi",
   "content_in_root": false,
-  "homeassistant": "2024.4.0"
+  "homeassistant": "2024.9.0"
 }


### PR DESCRIPTION
`2024-08-28 12:14:46.197 WARNING (ImportExecutor_0) [homeassistant.const] POWER_VOLT_AMPERE_REACTIVE was used from solaredge_modbus_multi, this is a deprecated constant which will be removed in HA Core 2025.9. Use UnitOfReactivePower.VOLT_AMPERE_REACTIVE instead, please report it to the author of the 'solaredge_modbus_multi' custom integration`