### PR TITLE
Remove redundant code for unique id check

### DIFF
--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_SCAN_INTERVAL
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -25,15 +25,6 @@ from .const import (
 from .helpers import device_list_from_string, host_valid
 
 
-@callback
-def solaredge_modbus_multi_entries(hass: HomeAssistant):
-    """Return the hosts already configured."""
-    return set(
-        entry.data[CONF_HOST].lower()
-        for entry in hass.config_entries.async_entries(DOMAIN)
-    )
-
-
 class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for SolarEdge Modbus Multi."""
 
@@ -68,8 +59,6 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 if not host_valid(user_input[CONF_HOST]):
                     errors[CONF_HOST] = "invalid_host"
-                elif user_input[CONF_HOST] in solaredge_modbus_multi_entries(self.hass):
-                    errors[CONF_HOST] = "already_configured"
                 elif not 1 <= user_input[CONF_PORT] <= 65535:
                     errors[CONF_PORT] = "invalid_tcp_port"
                 elif not 1 <= inverter_count <= 32:


### PR DESCRIPTION
Calling self._abort_if_unique_id_configured() handles this condition.