### PR TITLE
Add requirement for pymodbus <3.8

### DIFF
--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/WillCodeForCats/solaredge-modbus-multi/issues",
   "loggers": ["custom_components.solaredge_modbus_multi"],
-  "requirements": ["pymodbus>=3.6.6"],
+  "requirements": ["pymodbus>=3.6.6,<3.8"],
   "version": "3.0.2"
 }


### PR DESCRIPTION
Pymodbus 3.8 contains API changes to the modbus exceptions enum (removes it) which is not backwards compatible.

May need to abstract or create our own class enum to be compatible with 3.6, 3.7, and 3.8.