### PR TITLE
ModbusExceptions constant class

### DIFF
--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -31,6 +31,11 @@ DOMAIN_REGEX = re.compile(
 class ModbusExceptions:
     """An enumeration of the valid modbus exceptions."""
 
+    """
+        Copied from pymodbus source:
+        https://github.com/pymodbus-dev/pymodbus/blob/a1c14c7a8fbea52618ba1cbc9933c1dd24c3339d/pymodbus/pdu/pdu.py#L72
+    """
+
     IllegalFunction = 0x01
     IllegalAddress = 0x02
     IllegalValue = 0x03

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -28,6 +28,21 @@ DOMAIN_REGEX = re.compile(
 )
 
 
+class ModbusExceptions:
+    """An enumeration of the valid modbus exceptions."""
+
+    IllegalFunction = 0x01
+    IllegalAddress = 0x02
+    IllegalValue = 0x03
+    SlaveFailure = 0x04
+    Acknowledge = 0x05
+    SlaveBusy = 0x06
+    NegativeAcknowledge = 0x07
+    MemoryParityError = 0x08
+    GatewayPathUnavailable = 0x0A
+    GatewayNoResponse = 0x0B
+
+
 class RetrySettings(IntEnum):
     """Retry settings when opening a connection to the inverter fails."""
 

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -47,16 +47,6 @@ class ModbusExceptions:
     GatewayPathUnavailable = 0x0A
     GatewayNoResponse = 0x0B
 
-    @classmethod
-    def decode(cls, code: int) -> str | None:
-        """Give an error code, translate it to a string error name."""
-        values = {
-            v: k
-            for k, v in iter(cls.__dict__.items())
-            if not k.startswith("__") and not callable(v)
-        }
-        return values.get(code, None)
-
 
 class RetrySettings(IntEnum):
     """Retry settings when opening a connection to the inverter fails."""

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -47,6 +47,16 @@ class ModbusExceptions:
     GatewayPathUnavailable = 0x0A
     GatewayNoResponse = 0x0B
 
+    @classmethod
+    def decode(cls, code: int) -> str | None:
+        """Give an error code, translate it to a string error name."""
+        values = {
+            v: k
+            for k, v in iter(cls.__dict__.items())
+            if not k.startswith("__") and not callable(v)
+        }
+        return values.get(code, None)
+
 
 class RetrySettings(IntEnum):
     """Retry settings when opening a connection to the inverter fails."""

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -507,22 +507,21 @@ class SolarEdgeModbusMultiHub:
         )
 
         if result.isError():
-            _LOGGER.debug(f"Unit {unit}: {result}")
 
             if type(result) is ModbusIOException:
                 raise ModbusIOError(result)
 
             if type(result) is ExceptionResponse:
                 if result.exception_code == ModbusExceptions.IllegalAddress:
-                    _LOGGER.debug(f"Read IllegalAddress: {result}")
+                    _LOGGER.debug(f"Unit {unit} Read IllegalAddress: {result}")
                     raise ModbusIllegalAddress(result)
 
                 if result.exception_code == ModbusExceptions.IllegalFunction:
-                    _LOGGER.debug(f"Read IllegalFunction: {result}")
+                    _LOGGER.debug(f"Unit {unit} Read IllegalFunction: {result}")
                     raise ModbusIllegalFunction(result)
 
                 if result.exception_code == ModbusExceptions.IllegalValue:
-                    _LOGGER.debug(f"Read IllegalValue: {result}")
+                    _LOGGER.debug(f"Unit {unit} Read IllegalValue: {result}")
                     raise ModbusIllegalValue(result)
 
             raise ModbusReadError(result)
@@ -596,19 +595,19 @@ class SolarEdgeModbusMultiHub:
 
                 if type(result) is ExceptionResponse:
                     if result.exception_code == ModbusExceptions.IllegalAddress:
-                        _LOGGER.debug(f"Write IllegalAddress: {result}")
+                        _LOGGER.debug(f"Unit {self._wr_unit} Write IllegalAddress: {result}")
                         raise HomeAssistantError(
                             "Address not supported at device at ID {self._wr_unit}."
                         )
 
                     if result.exception_code == ModbusExceptions.IllegalFunction:
-                        _LOGGER.debug(f"Write IllegalFunction: {result}")
+                        _LOGGER.debug(f"Unit {self._wr_unit} Write IllegalFunction: {result}")
                         raise HomeAssistantError(
                             "Function not supported by device at ID {self._wr_unit}."
                         )
 
                     if result.exception_code == ModbusExceptions.IllegalValue:
-                        _LOGGER.debug(f"Write IllegalValue: {result}")
+                        _LOGGER.debug(f"Unit {self._wr_unit} Write IllegalValue: {result}")
                         raise HomeAssistantError(
                             "Value invalid for device at ID {self._wr_unit}."
                         )

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -15,7 +15,7 @@ try:
     from pymodbus.constants import Endian
     from pymodbus.exceptions import ConnectionException, ModbusIOException
     from pymodbus.payload import BinaryPayloadDecoder
-    from pymodbus.pdu import ExceptionResponse, ModbusExceptions
+    from pymodbus.pdu import ExceptionResponse
 except ImportError:
     raise ImportError("pymodbus is not installed, or pymodbus version is not supported")
 
@@ -28,6 +28,7 @@ from .const import (
     ConfDefaultStr,
     ConfName,
     ModbusDefaults,
+    ModbusExceptions,
     RetrySettings,
     SolarEdgeTimeouts,
     SunSpecNotImpl,

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -516,12 +516,15 @@ class SolarEdgeModbusMultiHub:
 
             if type(result) is ExceptionResponse:
                 if result.exception_code == ModbusExceptions.IllegalAddress:
+                    _LOGGER.debug(f"Read IllegalAddress: {result}")
                     raise ModbusIllegalAddress(result)
 
                 if result.exception_code == ModbusExceptions.IllegalFunction:
+                    _LOGGER.debug(f"Read IllegalFunction: {result}")
                     raise ModbusIllegalFunction(result)
 
                 if result.exception_code == ModbusExceptions.IllegalValue:
+                    _LOGGER.debug(f"Read IllegalValue: {result}")
                     raise ModbusIllegalValue(result)
 
             raise ModbusReadError(result)

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -595,19 +595,25 @@ class SolarEdgeModbusMultiHub:
 
                 if type(result) is ExceptionResponse:
                     if result.exception_code == ModbusExceptions.IllegalAddress:
-                        _LOGGER.debug(f"Unit {self._wr_unit} Write IllegalAddress: {result}")
+                        _LOGGER.debug(
+                            f"Unit {self._wr_unit} Write IllegalAddress: {result}"
+                        )
                         raise HomeAssistantError(
                             "Address not supported at device at ID {self._wr_unit}."
                         )
 
                     if result.exception_code == ModbusExceptions.IllegalFunction:
-                        _LOGGER.debug(f"Unit {self._wr_unit} Write IllegalFunction: {result}")
+                        _LOGGER.debug(
+                            f"Unit {self._wr_unit} Write IllegalFunction: {result}"
+                        )
                         raise HomeAssistantError(
                             "Function not supported by device at ID {self._wr_unit}."
                         )
 
                     if result.exception_code == ModbusExceptions.IllegalValue:
-                        _LOGGER.debug(f"Unit {self._wr_unit} Write IllegalValue: {result}")
+                        _LOGGER.debug(
+                            f"Unit {self._wr_unit} Write IllegalValue: {result}"
+                        )
                         raise HomeAssistantError(
                             "Value invalid for device at ID {self._wr_unit}."
                         )

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -10,7 +10,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity import DeviceInfo
-
 from pymodbus.client import AsyncModbusTcpClient
 from pymodbus.constants import Endian
 from pymodbus.exceptions import ConnectionException, ModbusIOException


### PR DESCRIPTION
Add my own class for ModbusExceptions constants used in pymodbus <3.8.0 to try and deal with unknown loading of incompatible modbus reported in issue #710 .