### PR TITLE
Update options flow for HA 2024.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ After rebooting Home Assistant, this integration can be configured through the i
 [WillCodeForCats/solaredge-modbus-multi/wiki](https://github.com/WillCodeForCats/solaredge-modbus-multi/wiki)
 
 ### Required Versions
-* Home Assistant 2024.12.0 or newer
+* Home Assistant 2025.1.0 or newer
 * Python 3.11 or newer
 * pymodbus 3.6.6 through 3.7.4
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ After rebooting Home Assistant, this integration can be configured through the i
 [WillCodeForCats/solaredge-modbus-multi/wiki](https://github.com/WillCodeForCats/solaredge-modbus-multi/wiki)
 
 ### Required Versions
-* Home Assistant 2024.9.0 or newer
+* Home Assistant 2024.12.0 or newer
 * Python 3.11 or newer
 * pymodbus 3.6.6 through 3.7.4
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ After rebooting Home Assistant, this integration can be configured through the i
 [WillCodeForCats/solaredge-modbus-multi/wiki](https://github.com/WillCodeForCats/solaredge-modbus-multi/wiki)
 
 ### Required Versions
-* Home Assistant 2025.1.0 or newer
+* Home Assistant 2024.12.0 or newer
 * Python 3.11 or newer
 * pymodbus 3.6.6 through 3.7.4
 

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -174,10 +174,6 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class SolaredgeModbusMultiOptionsFlowHandler(OptionsFlow):
     """Handle an options flow for SolarEdge Modbus Multi."""
 
-    def __init__(self, config_entry: ConfigEntry):
-        """Initialize options flow."""
-        self.config_entry = config_entry
-
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "SolarEdge Modbus Multi",
   "content_in_root": false,
-  "homeassistant": "2024.9.0"
+  "homeassistant": "2024.12.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "SolarEdge Modbus Multi",
   "content_in_root": false,
-  "homeassistant": "2025.1.0"
+  "homeassistant": "2024.12.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "SolarEdge Modbus Multi",
   "content_in_root": false,
-  "homeassistant": "2024.12.0"
+  "homeassistant": "2025.1.0"
 }


### PR DESCRIPTION
Update options flow for HA 2024.12.0. OptionsFlow class now sets config_entry, so we don't need to do that anymore.