### PR TITLE
Updates to modbus disconnect

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -488,6 +488,8 @@ class SolarEdgeModbusMultiHub:
             if clear_client:
                 self._client = None
 
+            await asyncio.sleep(1)
+
     async def shutdown(self) -> None:
         """Shut down the hub and disconnect."""
 

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -486,8 +486,8 @@ class SolarEdgeModbusMultiHub:
 
             try:
                 self._client.close()
-            except ModbusException as exception_error:
-                _LOGGER.error(str(exception_error))
+            except ModbusException as e:
+                _LOGGER.error(f"Modbus error: {e}")
 
             if clear_client:
                 del self._client

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -487,7 +487,7 @@ class SolarEdgeModbusMultiHub:
             try:
                 self._client.close()
             except ModbusException as e:
-                _LOGGER.error(f"Modbus error: {e}")
+                _LOGGER.error(f"ModbusException on close: {e}")
 
             if clear_client:
                 del self._client

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity import DeviceInfo
 from pymodbus.client import AsyncModbusTcpClient
 from pymodbus.constants import Endian
-from pymodbus.exceptions import ConnectionException, ModbusIOException
+from pymodbus.exceptions import ConnectionException, ModbusException, ModbusIOException
 from pymodbus.payload import BinaryPayloadDecoder
 from pymodbus.pdu import ExceptionResponse
 
@@ -483,7 +483,11 @@ class SolarEdgeModbusMultiHub:
                     f"(clear_client={clear_client})."
                 )
             )
-            self._client.close()
+
+            try:
+                self._client.close()
+            except ModbusException as exception_error:
+                _LOGGER.error(str(exception_error))
 
             if clear_client:
                 self._client = None

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -490,6 +490,7 @@ class SolarEdgeModbusMultiHub:
                 _LOGGER.error(str(exception_error))
 
             if clear_client:
+                del self._client
                 self._client = None
 
             await asyncio.sleep(1)


### PR DESCRIPTION
This PR adds some things used in HA core to our disconnect function.

* Delay 1 second on modbus close (idea from core PR#130038)
* Delete client object (from modbus core integration)
* Catch exceptions from close() (from modbus core integration)