### PR TITLE
Change config entry unique ID to address string

### DIFF
--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -146,9 +146,13 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     )
                     this_unique_id = f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}"
 
-                    self._async_abort_entries_match(
-                        {"host": user_input[CONF_HOST], "port": user_input[CONF_PORT]}
-                    )
+                    if this_unique_id != config_entry.unique_id:
+                        self._async_abort_entries_match(
+                            {
+                                "host": user_input[CONF_HOST],
+                                "port": user_input[CONF_PORT],
+                            }
+                        )
 
                     return self.async_update_reload_and_abort(
                         config_entry,

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -146,6 +146,10 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     )
                     this_unique_id = f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}"
 
+                    self._async_abort_entries_match(
+                        {"host": user_input[CONF_HOST], "port": user_input[CONF_PORT]}
+                    )
+
                     return self.async_update_reload_and_abort(
                         config_entry,
                         unique_id=this_unique_id,

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -144,10 +144,11 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     user_input[ConfName.DEVICE_LIST] = device_list_from_string(
                         user_input[ConfName.DEVICE_LIST]
                     )
+                    this_unique_id = f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}"
 
                     return self.async_update_reload_and_abort(
                         config_entry,
-                        unique_id=config_entry.unique_id,
+                        unique_id=this_unique_id,
                         data={**config_entry.data, **user_input},
                         reason="reconfigure_successful",
                     )

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -84,7 +84,8 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 elif not 1 <= inverter_count <= 32:
                     errors[ConfName.DEVICE_LIST] = "invalid_inverter_count"
                 else:
-                    await self.async_set_unique_id(user_input[CONF_HOST])
+                    new_unique_id = f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}"
+                    await self.async_set_unique_id(new_unique_id)
 
                     self._abort_if_unique_id_configured()
 

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -9,20 +9,11 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_SCAN_INTERVAL
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import DEFAULT_NAME, DOMAIN, ConfDefaultFlag, ConfDefaultInt, ConfName
 from .helpers import host_valid
-
-
-@callback
-def solaredge_modbus_multi_entries(hass: HomeAssistant):
-    """Return the hosts already configured."""
-    return set(
-        entry.data[CONF_HOST].lower()
-        for entry in hass.config_entries.async_entries(DOMAIN)
-    )
 
 
 class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -48,8 +39,6 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if not host_valid(user_input[CONF_HOST]):
                 errors[CONF_HOST] = "invalid_host"
-            elif user_input[CONF_HOST] in solaredge_modbus_multi_entries(self.hass):
-                errors[CONF_HOST] = "already_configured"
             elif user_input[CONF_PORT] < 1:
                 errors[CONF_PORT] = "invalid_tcp_port"
             elif user_input[CONF_PORT] > 65535:
@@ -70,6 +59,7 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 await self.async_set_unique_id(user_input[CONF_HOST])
                 self._abort_if_unique_id_configured()
+
                 return self.async_create_entry(
                     title=user_input[CONF_NAME], data=user_input
                 )

--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -49,7 +49,7 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for SolarEdge Modbus Multi."""
 
     VERSION = 2
-    MINOR_VERSION = 0
+    MINOR_VERSION = 1
 
     @staticmethod
     @callback

--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/WillCodeForCats/solaredge-modbus-multi/issues",
   "loggers": ["custom_components.solaredge_modbus_multi"],
   "requirements": ["pymodbus>=3.6.6,<3.8"],
-  "version": "3.0.5"
+  "version": "3.0.6-pre.1"
 }

--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/WillCodeForCats/solaredge-modbus-multi/issues",
   "loggers": ["custom_components.solaredge_modbus_multi"],
   "requirements": ["pymodbus>=3.6.6,<3.8"],
-  "version": "3.0.6-pre.1"
+  "version": "3.0.6-pre.2"
 }

--- a/custom_components/solaredge_modbus_multi/repairs.py
+++ b/custom_components/solaredge_modbus_multi/repairs.py
@@ -64,9 +64,12 @@ class CheckConfigurationRepairFlow(RepairsFlow):
                     user_input[ConfName.DEVICE_LIST] = device_list_from_string(
                         user_input[ConfName.DEVICE_LIST]
                     )
+                    this_unique_id = f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}"
 
                     self.hass.config_entries.async_update_entry(
-                        self._entry, data={**self._entry.data, **user_input}
+                        self._entry,
+                        unique_id=this_unique_id,
+                        data={**self._entry.data, **user_input},
                     )
 
                     return self.async_create_entry(title="", data={})

--- a/custom_components/solaredge_modbus_multi/repairs.py
+++ b/custom_components/solaredge_modbus_multi/repairs.py
@@ -65,12 +65,14 @@ class CheckConfigurationRepairFlow(RepairsFlow):
                         user_input[ConfName.DEVICE_LIST]
                     )
                     this_unique_id = f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}"
-
-                    if (
+                    existing_entry = (
                         self.hass.config_entries.async_entry_for_domain_unique_id(
                             DOMAIN, this_unique_id
                         )
-                        is not None
+                    )
+
+                    if (
+                        existing_entry is not None
                         and self._entry.unique_id != this_unique_id
                     ):
                         errors[CONF_HOST] = "already_configured"

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -30,7 +30,7 @@
       "empty_device_id": "The ID list contains an empty or undefined value."
     },
     "abort": {
-      "already_configured": "Device is already configured",
+      "already_configured": "Host and port is already configured in another hub.",
       "reconfigure_successful": "Re-configuration was successful"
     }
   },
@@ -93,7 +93,8 @@
           "invalid_tcp_port": "Valid port range is 1 to 65535.",
           "invalid_range_format": "Entry looks like a range but only one '-' per range is allowed.",
           "invalid_range_lte": "Starting ID in a range must be less than or equal to the end ID.",
-          "empty_device_id": "The ID list contains an empty or undefined value."
+          "empty_device_id": "The ID list contains an empty or undefined value.",
+          "already_configured": "Host and port is already configured in another hub."
         }
       }
     }

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -30,7 +30,7 @@
       "empty_device_id": "Die ID-Liste enthält einen leeren oder undefinierten Wert."
     },
     "abort": {
-      "already_configured": "Gerät ist bereits konfiguriert",
+      "already_configured": "Host und Port sind bereits in einem anderen Hub konfiguriert.",
       "reconfigure_successful": "Die Neukonfiguration war erfolgreich"
     }
   },
@@ -94,7 +94,8 @@
           "invalid_tcp_port": "Der gültige Portbereich ist 1 bis 65535.",
           "invalid_range_format": "Der Eintrag sieht aus wie ein Bereich, es ist jedoch nur ein „-“ pro Bereich zulässig.",
           "invalid_range_lte": "Die Start-ID in einem Bereich muss kleiner oder gleich der End-ID sein.",
-          "empty_device_id": "Die ID-Liste enthält einen leeren oder undefinierten Wert."
+          "empty_device_id": "Die ID-Liste enthält einen leeren oder undefinierten Wert.",
+          "already_configured": "Host und Port sind bereits in einem anderen Hub konfiguriert."
         }
       }
     }

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -30,7 +30,7 @@
       "empty_device_id": "The ID list contains an empty or undefined value."
     },
     "abort": {
-      "already_configured": "Device is already configured",
+      "already_configured": "Host and port is already configured in another hub.",
       "reconfigure_successful": "Re-configuration was successful"
     }
   },
@@ -93,7 +93,8 @@
           "invalid_tcp_port": "Valid port range is 1 to 65535.",
           "invalid_range_format": "Entry looks like a range but only one '-' per range is allowed.",
           "invalid_range_lte": "Starting ID in a range must be less than or equal to the end ID.",
-          "empty_device_id": "The ID list contains an empty or undefined value."
+          "empty_device_id": "The ID list contains an empty or undefined value.",
+          "already_configured": "Host and port is already configured in another hub."
         }
       }
     }

--- a/custom_components/solaredge_modbus_multi/translations/fr.json
+++ b/custom_components/solaredge_modbus_multi/translations/fr.json
@@ -30,7 +30,7 @@
       "empty_device_id": "La liste d'ID contient une valeur vide ou non définie."
     },
     "abort": {
-      "already_configured": "L'appareil est déjà configuré",
+      "already_configured": "L'hôte et le port sont déjà configurés dans un autre hub.",
       "reconfigure_successful": "La reconfiguration a réussi"
     }
   },
@@ -94,7 +94,8 @@
           "invalid_tcp_port": "La plage de ports valide est comprise entre 1 et 65535.",
           "invalid_range_format": "L'entrée ressemble à une plage mais un seul « - » par plage est autorisé.",
           "invalid_range_lte": "L’ID de début d’une plage doit être inférieur ou égal à l’ID de fin.",
-          "empty_device_id": "La liste d'ID contient une valeur vide ou non définie."
+          "empty_device_id": "La liste d'ID contient une valeur vide ou non définie.",
+          "already_configured": "L'hôte et le port sont déjà configurés dans un autre hub."
         }
       }
     }

--- a/custom_components/solaredge_modbus_multi/translations/it.json
+++ b/custom_components/solaredge_modbus_multi/translations/it.json
@@ -30,7 +30,7 @@
       "empty_device_id": "L'elenco ID contiene un valore vuoto o non definito."
     },
     "abort": {
-      "already_configured": "Il dispositivo è già configurato",
+      "already_configured": "L'host e la porta sono già configurati in un altro hub.",
       "reconfigure_successful": "La riconfigurazione ha avuto successo"
     }
   },
@@ -94,7 +94,8 @@
           "invalid_tcp_port": "L'intervallo di porte valido è compreso tra 1 e 65535.",
           "invalid_range_format": "L'immissione sembra un intervallo ma è consentito solo un '-' per intervallo.",
           "invalid_range_lte": "L'ID iniziale in un intervallo deve essere inferiore o uguale all'ID finale.",
-          "empty_device_id": "L'elenco ID contiene un valore vuoto o non definito."
+          "empty_device_id": "L'elenco ID contiene un valore vuoto o non definito.",
+          "already_configured": "L'host e la porta sono già configurati in un altro hub."
         }
       }
     }

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -30,7 +30,7 @@
       "empty_device_id": "ID-listen inneholder en tom eller udefinert verdi."
     },
     "abort": {
-      "already_configured": "Enheten er allerede konfigurert",
+      "already_configured": "Vert og port er allerede konfigurert i en annen hub.",
       "reconfigure_successful": "Omkonfigureringen var vellykket"
     }
   },
@@ -94,7 +94,8 @@
           "invalid_tcp_port": "Gyldig portområde er 1 til 65535.",
           "invalid_range_format": "Oppføring ser ut som et område, men bare én '-' per område er tillatt.",
           "invalid_range_lte": "Start-ID i et område må være mindre enn eller lik slutt-ID.",
-          "empty_device_id": "ID-listen inneholder en tom eller udefinert verdi."
+          "empty_device_id": "ID-listen inneholder en tom eller udefinert verdi.",
+          "already_configured": "Vert og port er allerede konfigurert i en annen hub."
         }
       }
     }

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -30,7 +30,7 @@
       "empty_device_id": "De ID-lijst bevat een lege of ongedefinieerde waarde."
     },
     "abort": {
-      "already_configured": "Apparaat is al geconfigureerd",
+      "already_configured": "Host en poort zijn al geconfigureerd in een andere hub.",
       "reconfigure_successful": "De herconfiguratie was succesvol"
     }
   },
@@ -94,7 +94,8 @@
           "invalid_tcp_port": "Geldig poortbereik is 1 tot 65535.",
           "invalid_range_format": "Invoer ziet eruit als een bereik, maar er is slechts één '-' per bereik toegestaan.",
           "invalid_range_lte": "De start-ID in een bereik moet kleiner zijn dan of gelijk zijn aan de eind-ID.",
-          "empty_device_id": "De ID-lijst bevat een lege of ongedefinieerde waarde."
+          "empty_device_id": "De ID-lijst bevat een lege of ongedefinieerde waarde.",
+          "already_configured": "Host en poort zijn al geconfigureerd in een andere hub."
         }
       }
     }

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -30,7 +30,7 @@
       "empty_device_id": "Lista identyfikatorów zawiera pustą lub niezdefiniowaną wartość."
     },
     "abort": {
-      "already_configured": "Urządzenie jest już skonfigurowane",
+      "already_configured": "Host i port są już skonfigurowane w innym koncentratorze.",
       "reconfigure_successful": "Ponowna konfiguracja przebiegła pomyślnie"
     }
   },
@@ -94,7 +94,8 @@
           "invalid_tcp_port": "Dozwolony zakres portów to od  1 do 65535.",
           "invalid_range_format": "Wpis wygląda jak zakres, ale dozwolony jest tylko jeden znak „-” na zakres.",
           "invalid_range_lte": "Początkowy identyfikator w zakresie musi być mniejszy lub równy identyfikatorowi końcowemu.",
-          "empty_device_id": "Lista identyfikatorów zawiera pustą lub niezdefiniowaną wartość."
+          "empty_device_id": "Lista identyfikatorów zawiera pustą lub niezdefiniowaną wartość.",
+          "already_configured": "Host i port są już skonfigurowane w innym koncentratorze."
         }
       }
     }


### PR DESCRIPTION
Change config entry unique ID to address string. This will allow device entries to share the same IP address (i.e. modbus proxy issue #638), but port must still be unique per hub/entry.