### PR TITLE
Update translations for advanced_power_control key

### DIFF
--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -44,7 +44,7 @@
           "detect_meters": "Messgeräte automatisch erkennen",
           "detect_batteries": "Batterien automatisch erkennen",
           "detect_extras": "Zusätzliche Entitäten automatisch erkennen",
-          "advanced_power_control": "Erweiterte Leistungssteuerung",
+          "advanced_power_control": "Optionen zur Leistungssteuerung",
           "sleep_after_write": "Befehlsverzögerung des Wechselrichters (Sekunden)"
         }
       },

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -44,7 +44,7 @@
           "detect_meters": "Automatisk oppdagelse av målere",
           "detect_batteries": "Automatisk gjenkjenning av batterier",
           "detect_extras": "Automatisk oppdage flere enheter",
-          "advanced_power_control": "Avansert strømkontroll",
+          "advanced_power_control": "Strømkontrollalternativer",
           "sleep_after_write": "Inverter Command Delay (sekunder)"
         }
       },

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -44,7 +44,7 @@
           "detect_meters": "Meters automatisch detecteren",
           "detect_batteries": "Batterijen automatisch detecteren",
           "detect_extras": "Automatische detectie van aanvullende entiteiten",
-          "advanced_power_control": "Geavanceerde stroomregeling",
+          "advanced_power_control": "Opties voor vermogensregeling",
           "sleep_after_write": "Omvormer commando vertraging (seconden)"
         }
       },

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -44,7 +44,7 @@
           "detect_meters": "Automatycznie wykryj liczniki",
           "detect_batteries": "Automatycznie wykryj baterie",
           "detect_extras": "Automatycznie wykrywaj dodatkowe elementy",
-          "advanced_power_control": "Zaawansowana kontrola mocy",
+          "advanced_power_control": "Opcje kontroli mocy",
           "sleep_after_write": "Opóźnienie polecenia falownika (sekundy)"
         }
       },


### PR DESCRIPTION
Some translations for Power Control Options didn't get updated, check all translations for this key and update.