### PR TITLE
Remove redundant log message

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -556,10 +556,6 @@ class SolarEdgeModbusMultiHub:
         )
 
         if len(result.registers) != rcount:
-            _LOGGER.error(
-                f"I{self._rr_unit}: Registers received != requested : "
-                f"{len(result.registers)} != {self._rr_count} at {self._rr_address}"
-            )
             raise ModbusReadError(
                 f"I{self._rr_unit}: Registers received != requested : "
                 f"{len(result.registers)} != {self._rr_count} at {self._rr_address}"


### PR DESCRIPTION
HA update coordinator should log this through the exception message.