### PR TITLE
Rename HeatSinkTemperature sensor name property

### DIFF
--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1203,7 +1203,7 @@ class HeatSinkTemperature(SolarEdgeSensorBase):
 
     @property
     def name(self) -> str:
-        return "Temp Sink"
+        return "Temperature"
 
     @property
     def native_value(self):


### PR DESCRIPTION
Rename HeatSinkTemperature sensor name property

This PR is because I don't like seeing "Temp Sink" as a sensor name when there's only one temperature value exposed by SolarEdge inverters.