### PR TITLE
Update ExceptionResponse import for pymodbus 3.11

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -16,8 +16,10 @@ from pymodbus.client.mixin import ModbusClientMixin
 from pymodbus.exceptions import ConnectionException, ModbusIOException
 
 try:
+    # for pymodbus 3.11.1 and newer
     from pymodbus.pdu.pdu import ExceptionResponse
 except ImportError:
+    # or backwards compatibility
     from pymodbus.pdu import ExceptionResponse
 
 from .const import (

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from pymodbus.client import AsyncModbusTcpClient
 from pymodbus.client.mixin import ModbusClientMixin
 from pymodbus.exceptions import ConnectionException, ModbusIOException
+
 try:
     from pymodbus.pdu.pdu import ExceptionResponse
 except ImportError:
@@ -107,7 +108,6 @@ class DeviceInvalid(SolarEdgeException):
 
 
 class SolarEdgeModbusMultiHub:
-
     def __init__(
         self,
         hass: HomeAssistant,
@@ -545,14 +545,10 @@ class SolarEdgeModbusMultiHub:
                 address=self._rr_address, count=self._rr_count, slave=self._rr_unit
             )
 
-        _LOGGER.debug(
-            f"I{self._rr_unit}: result is error: {result.isError()} "
-        )
+        _LOGGER.debug(f"I{self._rr_unit}: result is error: {result.isError()} ")
 
         if result.isError():
-            _LOGGER.debug(
-                f"I{self._rr_unit}: error result: {type(result)} "
-            )
+            _LOGGER.debug(f"I{self._rr_unit}: error result: {type(result)} ")
 
             if type(result) is ModbusIOException:
                 raise ModbusIOError(result)

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -110,6 +110,7 @@ class DeviceInvalid(SolarEdgeException):
 
 
 class SolarEdgeModbusMultiHub:
+
     def __init__(
         self,
         hass: HomeAssistant,

--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/WillCodeForCats/solaredge-modbus-multi/issues",
   "loggers": ["custom_components.solaredge_modbus_multi"],
   "requirements": ["pymodbus>=3.8.3"],
-  "version": "3.1.6"
+  "version": "3.2.0-pre.1"
 }

--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/WillCodeForCats/solaredge-modbus-multi/issues",
   "loggers": ["custom_components.solaredge_modbus_multi"],
   "requirements": ["pymodbus>=3.8.3"],
-  "version": "3.2.0-pre.1"
+  "version": "3.1.7-pre.1"
 }


### PR DESCRIPTION
Update ExceptionResponse import for pymodbus 3.11 with fallback to previous import for pymodbus 3.9