### PR TITLE
Add a "Last Update" timestamp sensor

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -348,12 +348,18 @@ class SolarEdgeModbusMultiHub:
         try:
             for inverter in self.inverters:
                 await inverter.read_modbus_data()
-
             for meter in self.meters:
                 await meter.read_modbus_data()
-
             for battery in self.batteries:
                 await battery.read_modbus_data()
+
+            timestamp = dt.now()
+            for inverter in self.inverters:
+                inverter.set_last_update(timestamp)
+            for meter in self.meters:
+                meter.set_last_update(timestamp)
+            for battery in self.batteries:
+                battery.set_last_update(timestamp)
 
         except ModbusReadError as e:
             self.disconnect()

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -727,7 +727,7 @@ class SolarEdgeModbusMultiHub:
     def hub_port(self) -> int:
         """Return the modbus client port."""
         return self._port
-        
+
     @property
     def hass_config(self):
         return self._hass.config
@@ -2567,7 +2567,7 @@ class SolarEdgeBattery:
                 f"{name} {display_value} {type(value)}"
             )
 
-    def set_last_update(self,timestamp) -> None:
+    def set_last_update(self, timestamp) -> None:
         self._last_update_timestamp = timestamp
 
     @property

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import importlib.metadata
 import inspect
 import logging
-import datetime as dt
 from collections import OrderedDict
 
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.util import dt
 from pymodbus.client import AsyncModbusTcpClient
 from pymodbus.client.mixin import ModbusClientMixin
 from pymodbus.exceptions import ConnectionException, ModbusIOException
@@ -475,7 +476,7 @@ class SolarEdgeModbusMultiHub:
         if not self.keep_modbus_open:
             self.disconnect()
 
-        timestamp = dt.now(tz=self.hub.hass_config.time_zone)
+        timestamp = dt.now()
         for inverter in self.inverters:
             inverter.set_last_update(timestamp)
         for meter in self.meters:
@@ -727,10 +728,6 @@ class SolarEdgeModbusMultiHub:
     def hub_port(self) -> int:
         """Return the modbus client port."""
         return self._port
-
-    @property
-    def hass_config(self):
-        return self._hass.config
 
     @property
     def option_storage_control(self) -> bool:
@@ -1908,7 +1905,7 @@ class SolarEdgeInverter:
         return True
 
     @property
-    def last_update(self) -> dt | None:
+    def last_update(self) -> datetime.datetime | None:
         return self._last_update_timestamp
 
 
@@ -2295,7 +2292,7 @@ class SolarEdgeMeter:
         self._via_device = (DOMAIN, device)
 
     @property
-    def last_update(self) -> dt | None:
+    def last_update(self) -> datetime.datetime | None:
         return self._last_update_timestamp
 
 
@@ -2609,5 +2606,5 @@ class SolarEdgeBattery:
         return self.hub.battery_energy_reset_cycles
 
     @property
-    def last_update(self) -> dt | None:
+    def last_update(self) -> datetime.datetime | None:
         return self._last_update_timestamp

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -4,6 +4,7 @@ import asyncio
 import importlib.metadata
 import inspect
 import logging
+import datetime as dt
 from collections import OrderedDict
 
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
@@ -474,6 +475,14 @@ class SolarEdgeModbusMultiHub:
         if not self.keep_modbus_open:
             self.disconnect()
 
+        timestamp = dt.now(tz=self.hub.hass_config.time_zone)
+        for inverter in self.inverters:
+            inverter.set_last_update(timestamp)
+        for meter in self.meters:
+            meter.set_last_update(timestamp)
+        for battery in self.batteries:
+            battery.set_last_update(timestamp)
+
         return True
 
     async def connect(self) -> None:
@@ -718,6 +727,10 @@ class SolarEdgeModbusMultiHub:
     def hub_port(self) -> int:
         """Return the modbus client port."""
         return self._port
+        
+    @property
+    def hass_config(self):
+        return self._hass.config
 
     @property
     def option_storage_control(self) -> bool:
@@ -828,6 +841,7 @@ class SolarEdgeInverter:
         self.advanced_power_control = None
         self.site_limit_control = None
         self._grid_status = None
+        self._last_update_timestamp = None
 
     async def init_device(self) -> None:
         """Set up data about the device from modbus."""
@@ -1858,6 +1872,9 @@ class SolarEdgeInverter:
         """Write inverter register."""
         await self.hub.write_registers(self.inverter_unit_id, address, payload)
 
+    def set_last_update(self, timestamp) -> None:
+        self._last_update_timestamp = timestamp
+
     @property
     def online(self) -> bool:
         """Device is online."""
@@ -1889,6 +1906,10 @@ class SolarEdgeInverter:
             return False
 
         return True
+
+    @property
+    def last_update(self) -> dt | None:
+        return self._last_update_timestamp
 
 
 class SolarEdgeMMPPTUnit:
@@ -1944,6 +1965,7 @@ class SolarEdgeMeter:
         self.inverter_common = self.hub.inverter_common[self.inverter_unit_id]
         self.mmppt_common = self.hub.mmppt_common[self.inverter_unit_id]
         self._via_device = None
+        self._last_update_timestamp = None
 
         try:
             self.start_address = METER_REG_BASE[self.meter_id]
@@ -2242,6 +2264,9 @@ class SolarEdgeMeter:
                 f"Meter {self.meter_id} ident incorrect or not installed."
             )
 
+    def set_last_update(self, timestamp) -> None:
+        self._last_update_timestamp = timestamp
+
     @property
     def online(self) -> bool:
         """Device is online."""
@@ -2269,6 +2294,10 @@ class SolarEdgeMeter:
     def via_device(self, device: str) -> None:
         self._via_device = (DOMAIN, device)
 
+    @property
+    def last_update(self) -> dt | None:
+        return self._last_update_timestamp
+
 
 class SolarEdgeBattery:
     """Defines a SolarEdge battery."""
@@ -2285,6 +2314,7 @@ class SolarEdgeBattery:
         self.has_parent = True
         self.inverter_common = self.hub.inverter_common[self.inverter_unit_id]
         self._via_device = None
+        self._last_update_timestamp = None
 
         try:
             self.start_address = BATTERY_REG_BASE[self.battery_id]
@@ -2537,6 +2567,9 @@ class SolarEdgeBattery:
                 f"{name} {display_value} {type(value)}"
             )
 
+    def set_last_update(self,timestamp) -> None:
+        self._last_update_timestamp = timestamp
+
     @property
     def online(self) -> bool:
         """Device is online."""
@@ -2574,3 +2607,7 @@ class SolarEdgeBattery:
     @property
     def battery_energy_reset_cycles(self) -> int:
         return self.hub.battery_energy_reset_cycles
+
+    @property
+    def last_update(self) -> dt | None:
+        return self._last_update_timestamp

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -2500,3 +2500,24 @@ class SolarEdgeDefaultControlSettings(SolarEdgeAdvancedPowerControlBlock):
             attrs["status"] = "ERROR"
 
         return attrs
+
+
+class SolarEdgeLastUpdate(SolarEdgeSensorBase):
+    device_class = SensorDeviceClass.TIMESTAMP
+    entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_last_update_timestamp"
+
+    @property
+    def name(self) -> str:
+        return "Last Update Timestamp"
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def native_value(self):
+        return self._platform.last_update

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -2515,7 +2515,7 @@ class SolarEdgeLastUpdate(SolarEdgeSensorBase):
 
     @property
     def name(self) -> str:
-        return "Last Update Timestamp"
+        return "Last Update"
 
     @property
     def available(self) -> bool:

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -61,6 +61,7 @@ async def async_setup_entry(
     entities = []
 
     for inverter in hub.inverters:
+        entities.append(SolarEdgeLastUpdate(inverter, config_entry, coordinator))
         entities.append(SolarEdgeDevice(inverter, config_entry, coordinator))
         entities.append(Version(inverter, config_entry, coordinator))
         entities.append(SolarEdgeInverterStatus(inverter, config_entry, coordinator))
@@ -120,6 +121,7 @@ async def async_setup_entry(
                 )
 
     for meter in hub.meters:
+        entities.append(SolarEdgeLastUpdate(meter, config_entry, coordinator))
         entities.append(SolarEdgeDevice(meter, config_entry, coordinator))
         entities.append(Version(meter, config_entry, coordinator))
         entities.append(MeterEvents(meter, config_entry, coordinator))
@@ -199,6 +201,7 @@ async def async_setup_entry(
         entities.append(MetervarhIE(meter, config_entry, coordinator, "Export_Q4_C"))
 
     for battery in hub.batteries:
+        entities.append(SolarEdgeLastUpdate(battery, config_entry, coordinator))
         entities.append(SolarEdgeDevice(battery, config_entry, coordinator))
         entities.append(Version(battery, config_entry, coordinator))
         entities.append(SolarEdgeBatteryAvgTemp(battery, config_entry, coordinator))

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import logging
 import re
 
@@ -2522,5 +2523,5 @@ class SolarEdgeLastUpdate(SolarEdgeSensorBase):
         return True
 
     @property
-    def native_value(self):
+    def native_value(self) -> datetime.datetime | None:
         return self._platform.last_update


### PR DESCRIPTION
Add a "Last Update" timestamp sensor to signal when a poll cycle is complete and provide the last time data was updated since the integration was started.

This entity can be used for a template trigger to signal when a poll is complete across all registers.