### PR TITLE
Change Last Update sensor to default disabled

### DIFF
--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -2523,5 +2523,9 @@ class SolarEdgeLastUpdate(SolarEdgeSensorBase):
         return True
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        return False
+
+    @property
     def native_value(self) -> datetime.datetime | None:
         return self._platform.last_update


### PR DESCRIPTION
Change the Last Update sensor added in #966 to default disabled. Creates excess entries for people who are not using this sensor, unless there is a way to have it enabled but exclude it from activity that I'm not aware of.