### PR TITLE
Fix checks for some control entites

### DIFF
--- a/custom_components/solaredge_modbus_multi/number.py
+++ b/custom_components/solaredge_modbus_multi/number.py
@@ -34,7 +34,7 @@ async def async_setup_entry(
     entities = []
 
     for inverter in hub.inverters:
-        """ Dynamic Power Control """
+        """Dynamic Power Control"""
         if hub.option_detect_extras and inverter.global_power_control:
             entities.append(
                 SolarEdgeActivePowerLimitSet(inverter, config_entry, coordinator)

--- a/custom_components/solaredge_modbus_multi/number.py
+++ b/custom_components/solaredge_modbus_multi/number.py
@@ -33,13 +33,18 @@ async def async_setup_entry(
 
     entities = []
 
-    """ Dynamic Power Control """
-    if hub.option_detect_extras:
-        for inverter in hub.inverters:
+    for inverter in hub.inverters:
+        """ Dynamic Power Control """
+        if hub.option_detect_extras and inverter.global_power_control:
             entities.append(
                 SolarEdgeActivePowerLimitSet(inverter, config_entry, coordinator)
             )
             entities.append(SolarEdgeCosPhiSet(inverter, config_entry, coordinator))
+
+        """ Power Control Block """
+        if hub.option_detect_extras and inverter.advanced_power_control:
+            entities.append(SolarEdgePowerReduce(inverter, config_entry, coordinator))
+            entities.append(SolarEdgeCurrentLimit(inverter, config_entry, coordinator))
 
     """ Power Control Options: Storage Control """
     if hub.option_storage_control is True:
@@ -62,12 +67,6 @@ async def async_setup_entry(
             entities.append(
                 SolarEdgeExternalProductionMax(inverter, config_entry, coordinator)
             )
-
-    """ Power Control Block """
-    if hub.option_detect_extras and inverter.advanced_power_control:
-        for inverter in hub.inverters:
-            entities.append(SolarEdgePowerReduce(inverter, config_entry, coordinator))
-            entities.append(SolarEdgeCurrentLimit(inverter, config_entry, coordinator))
 
     if entities:
         async_add_entities(entities)

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -95,8 +95,7 @@ async def async_setup_entry(
             )
             entities.append(SolarEdgeCosPhi(inverter, config_entry, coordinator))
 
-        """ Power Control Block """
-        if hub.option_detect_extras:
+        if hub.option_detect_extras and inverter.advanced_power_control:
             entities.append(
                 SolarEdgeCommitControlSettings(inverter, config_entry, coordinator)
             )

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -88,7 +88,7 @@ async def async_setup_entry(
         entities.append(DCPower(inverter, config_entry, coordinator))
         entities.append(HeatSinkTemperature(inverter, config_entry, coordinator))
 
-        if hub.option_detect_extras:
+        if hub.option_detect_extras and inverter.global_power_control:
             entities.append(SolarEdgeRRCR(inverter, config_entry, coordinator))
             entities.append(
                 SolarEdgeActivePowerLimit(inverter, config_entry, coordinator)


### PR DESCRIPTION
Some control entities were appearing on inverter devices that didn't actually support them. Fix these checks so they don't appear (even though they would show unavailable state they shouldn't be there at all if not supported by the inverter).