### PR TITLE
Add Status Vendor 4 sensor

### DIFF
--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -274,8 +274,30 @@ VENDOR_STATUS = {
 
 VENDOR4_STATUS: dict[int, dict[int, str]] = {
     # controller: {error_code: "description"}
-    0x3: {0x6E: "Meter Communication Error"},
-    0x18: {0xC7: "Rapid Shutdown (RSD) Error"},
+    0x3: {
+        0x2: "Inverter Communication Error",
+        0x1C: "Battery without Firmware",
+        0x6B: "Battery Communication Error",
+        0x6E: "Meter Communication Error",
+        0xA5: "Modbus Routing Packets Debug",
+    },
+    0x18: {
+        0x14: "Inv. Power Error - No Code",
+        0x1C: "V-L1 Min1",
+        0x3D: "I-RCD Step",
+        0x40: "F-L1 Max1",
+        0x61: "Vin Buck Max",
+        0xA5: "Tz Over Current 3",
+        0xB5: "Vcap11 Surge",
+        0xB6: "Vcap12 Surge",
+        0xB9: "Vcap31 Surge",
+        0xBA: "Vcap33 Surge",
+        0xBE: "Swing Rdiff Overheat",
+        0xBF: "Swing Rcommon Overheat",
+        0xC7: "Rapid Shutdown (RSD) Error",
+        0xD6: "Multiple Seq. GB",
+        0x100: "Arc Detected",
+    },
 }
 
 SUNSPEC_DID = {

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -272,6 +272,10 @@ VENDOR_STATUS = {
     256: "Arc Detected",
 }
 
+VENDOR4_STATUS: dict[int, dict[int, str]] = {
+    # controller: {error_code: "description"}
+}
+
 SUNSPEC_DID = {
     101: "Single Phase Inverter",
     102: "Split Phase Inverter",

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -274,6 +274,8 @@ VENDOR_STATUS = {
 
 VENDOR4_STATUS: dict[int, dict[int, str]] = {
     # controller: {error_code: "description"}
+    0x3: {0x6E: "Meter Communication Error"},
+    0x18: {0xC7: "Rapid Shutdown (RSD) Error"},
 }
 
 SUNSPEC_DID = {

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -30,6 +30,8 @@ DOMAIN_REGEX = re.compile(
     re.IGNORECASE,
 )
 
+STATUS_VENDOR4_VERSION = "3.20.0"
+
 
 class ModbusExceptions:
     """An enumeration of the valid modbus exceptions."""

--- a/custom_components/solaredge_modbus_multi/diagnostics.py
+++ b/custom_components/solaredge_modbus_multi/diagnostics.py
@@ -60,6 +60,7 @@ async def async_get_config_entry_diagnostics(
                 "mmppt": format_values(inverter.decoded_mmppt),
                 "has_battery": inverter.has_battery,
                 "storage_control": format_values(inverter.decoded_storage_control),
+                "use_status_vendor4": inverter.use_status_vendor4,
             }
         }
 

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1135,10 +1135,6 @@ class SolarEdgeInverter:
                 + inverter_data.registers[30:40]
             )
 
-            if self.use_status_vendor4:
-                int16_fields.append("I_Status_Vendor4")
-                int16_data = int16_data + inverter_data.registers[41:43]
-
             self.decoded_model.update(
                 OrderedDict(
                     zip(
@@ -1165,6 +1161,21 @@ class SolarEdgeInverter:
                     ]
                 )
             )
+
+            if self.use_status_vendor4:
+                self.decoded_model.update(
+                    OrderedDict(
+                        [
+                            (
+                                "I_Status_Vendor4",
+                                ModbusClientMixin.convert_from_registers(
+                                    inverter_data.registers[40:42],
+                                    data_type=ModbusClientMixin.DATATYPE.UINT32,
+                                ),
+                            ),
+                        ]
+                    )
+                )
 
             if (
                 self.decoded_model["C_SunSpec_DID"] == SunSpecNotImpl.UINT16

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1177,7 +1177,7 @@ class SolarEdgeInverter:
                     unit=self.inverter_unit_id, address=40119, rcount=2
                 )
                 self.decoded_model.update(
-                    OrderedDict(
+                    dict(
                         [
                             (
                                 "I_Status_Vendor4",

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1062,8 +1062,9 @@ class SolarEdgeInverter:
                 )
             )
 
+            rcount = 40 if self.use_status_vendor4 else 42
             inverter_data = await self.hub.modbus_read_holding_registers(
-                unit=self.inverter_unit_id, address=40069, rcount=40
+                unit=self.inverter_unit_id, address=40069, rcount=rcount
             )
 
             uint16_fields = [
@@ -1133,6 +1134,11 @@ class SolarEdgeInverter:
                 + [inverter_data.registers[28]]
                 + inverter_data.registers[30:40]
             )
+
+            if self.use_status_vendor4:
+                int16_fields.append("I_Status_Vendor4")
+                int16_data = int16_data + inverter_data.registers[41:43]
+
             self.decoded_model.update(
                 OrderedDict(
                     zip(

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -8,6 +8,10 @@ import logging
 from collections import OrderedDict
 
 from awesomeversion import AwesomeVersion
+from awesomeversion.exceptions import (
+    AwesomeVersionCompareException,
+    AwesomeVersionStrategyException,
+)
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -1040,7 +1044,15 @@ class SolarEdgeInverter:
         self.name = f"{self.hub.hub_id.capitalize()} I{self.inverter_unit_id}"
         self.uid_base = f"{self.model}_{self.serial}"
 
-        self._use_status_vendor4 = this_ver >= AwesomeVersion(STATUS_VENDOR4_VERSION)
+        try:
+            this_ver = AwesomeVersion(self.decoded_common["C_Version"])
+            self._use_status_vendor4 = this_ver >= AwesomeVersion(
+                STATUS_VENDOR4_VERSION
+            )
+        except (AwesomeVersionCompareException, AwesomeVersionStrategyException) as e:
+            _LOGGER.error(
+                f"Error checking inverter version: {e}. Please report this issue."
+            )
 
         if self.decoded_mmppt is not None:
             for unit_index in range(self.decoded_mmppt["mmppt_Units"]):

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1074,7 +1074,7 @@ class SolarEdgeInverter:
                 )
             )
 
-            rcount = 40 if self.use_status_vendor4 else 42
+            rcount = 42 if self.use_status_vendor4 else 40
             inverter_data = await self.hub.modbus_read_holding_registers(
                 unit=self.inverter_unit_id, address=40069, rcount=rcount
             )

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 from collections import OrderedDict
 
+from awesomeversion import AwesomeVersion
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -29,6 +30,7 @@ from .const import (
     DOMAIN,
     METER_REG_BASE,
     PYMODBUS_REQUIRED_VERSION,
+    STATUS_VENDOR4_VERSION,
     ConfDefaultFlag,
     ConfDefaultInt,
     ConfDefaultStr,
@@ -845,6 +847,7 @@ class SolarEdgeInverter:
         self.site_limit_control = None
         self._grid_status = None
         self._last_update_timestamp = None
+        self._use_status_vendor4 = False
 
     async def init_device(self) -> None:
         """Set up data about the device from modbus."""
@@ -1036,6 +1039,8 @@ class SolarEdgeInverter:
         self.device_address = self.decoded_common["C_Device_address"]
         self.name = f"{self.hub.hub_id.capitalize()} I{self.inverter_unit_id}"
         self.uid_base = f"{self.model}_{self.serial}"
+
+        self._use_status_vendor4 = this_ver >= AwesomeVersion(STATUS_VENDOR4_VERSION)
 
         if self.decoded_mmppt is not None:
             for unit_index in range(self.decoded_mmppt["mmppt_Units"]):
@@ -1913,6 +1918,10 @@ class SolarEdgeInverter:
     @property
     def last_update(self) -> datetime.datetime | None:
         return self._last_update_timestamp
+
+    @property
+    def use_status_vendor4(self) -> bool:
+        return self._use_status_vendor4
 
 
 class SolarEdgeMMPPTUnit:

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1074,9 +1074,8 @@ class SolarEdgeInverter:
                 )
             )
 
-            rcount = 42 if self.use_status_vendor4 else 40
             inverter_data = await self.hub.modbus_read_holding_registers(
-                unit=self.inverter_unit_id, address=40069, rcount=rcount
+                unit=self.inverter_unit_id, address=40069, rcount=40
             )
 
             uint16_fields = [
@@ -1175,13 +1174,16 @@ class SolarEdgeInverter:
             )
 
             if self.use_status_vendor4:
+                inverter_data = await self.hub.modbus_read_holding_registers(
+                    unit=self.inverter_unit_id, address=40119, rcount=2
+                )
                 self.decoded_model.update(
                     OrderedDict(
                         [
                             (
                                 "I_Status_Vendor4",
                                 ModbusClientMixin.convert_from_registers(
-                                    inverter_data.registers[40:42],
+                                    inverter_data.registers[0:2],
                                     data_type=ModbusClientMixin.DATATYPE.UINT32,
                                 ),
                             ),

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1403,6 +1403,10 @@ class StatusVendor(SolarEdgeSensorBase):
         return "Status Vendor"
 
     @property
+    def entity_registry_enabled_default(self) -> bool:
+        return not self._platform.use_status_vendor4
+
+    @property
     def native_value(self):
         try:
             if self._platform.decoded_model["I_Status_Vendor"] == SunSpecNotImpl.INT16:

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -68,6 +68,8 @@ async def async_setup_entry(
         entities.append(Version(inverter, config_entry, coordinator))
         entities.append(SolarEdgeInverterStatus(inverter, config_entry, coordinator))
         entities.append(StatusVendor(inverter, config_entry, coordinator))
+        if inverter.use_status_vendor4:
+            entities.append(StatusVendor4(inverter, config_entry, coordinator))
         entities.append(ACCurrentSensor(inverter, config_entry, coordinator))
         entities.append(ACCurrentSensor(inverter, config_entry, coordinator, "A"))
         entities.append(ACCurrentSensor(inverter, config_entry, coordinator, "B"))

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1455,7 +1455,7 @@ class StatusVendor4(SolarEdgeSensorBase):
     def native_value(self):
         try:
             value = self._platform.decoded_model["I_Status_Vendor4"]
-            controller = (value >> 16) & 0xFFFF
+            controller = (value >> 24) & 0xFF
             error = value & 0xFFFF
             return f"{controller:X}x{error:X}"
         except TypeError:
@@ -1466,7 +1466,7 @@ class StatusVendor4(SolarEdgeSensorBase):
         try:
             value = self._platform.decoded_model["I_Status_Vendor4"]
 
-            controller = (value >> 16) & 0xFFFF
+            controller = (value >> 24) & 0xFF
             error = value & 0xFFFF
             attrs = {
                 "controller": hex(controller),

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -41,6 +41,7 @@ from .const import (
     RRCR_STATUS,
     SUNSPEC_DID,
     SUNSPEC_SF_RANGE,
+    VENDOR4_STATUS,
     VENDOR_STATUS,
     BatteryLimit,
     SunSpecAccum,
@@ -1425,6 +1426,60 @@ class StatusVendor(SolarEdgeSensorBase):
                 return None
 
         except KeyError:
+            return None
+
+
+class StatusVendor4(SolarEdgeSensorBase):
+    entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_status_vendor4"
+
+    @property
+    def name(self) -> str:
+        return "Status Vendor 4"
+
+    @property
+    def available(self) -> bool:
+        return (
+            super().available
+            and "I_Status_Vendor4" in self._platform.decoded_model
+            and self._platform.decoded_model["I_Status_Vendor4"]
+            != SunSpecNotImpl.UINT32
+        )
+
+    @property
+    def native_value(self):
+        try:
+            value = self._platform.decoded_model["I_Status_Vendor4"]
+            controller = (value >> 16) & 0xFFFF
+            error = value & 0xFFFF
+            return f"{controller:X}x{error:X}"
+        except TypeError:
+            return None
+
+    @property
+    def extra_state_attributes(self):
+        try:
+            value = self._platform.decoded_model["I_Status_Vendor4"]
+
+            controller = (value >> 16) & 0xFFFF
+            error = value & 0xFFFF
+            attrs = {
+                "controller": hex(controller),
+                "error_code": hex(error),
+            }
+
+            if controller in VENDOR4_STATUS and error in VENDOR4_STATUS[controller]:
+                attrs["description"] = VENDOR4_STATUS[controller][error]
+
+            return attrs
+
+        except KeyError:
+            return None
+
+        except TypeError:
             return None
 
 


### PR DESCRIPTION
Add a Status Vendor 4 sensor if inverter if firmware version detected during setup is 3.20.0 and newer.

This will display "0x0" formatted error codes to match the error codes you would see in SetApp.

The VENDOR4_STATUS dict will need expanding. This PR only includes two to start with. Tested with 3x6E by disconnecting the meter (removed power) long enough to generate the error in SetApp and for HA to poll it.