### PR TITLE
Fix I_Status and I_Status_Vendor register type: uint16 not int16

### DIFF
--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -234,7 +234,7 @@ DEVICE_STATUS_TEXT = {
 }
 
 VENDOR_STATUS = {
-    SunSpecNotImpl.INT16: None,
+    SunSpecNotImpl.UINT16: None,
     0: "No Error",
     17: "Temperature Too High",
     25: "Isolation Faults",

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1094,6 +1094,8 @@ class SolarEdgeInverter:
                 "AC_Energy_WH_SF",
                 "I_DC_Current",
                 "I_DC_Voltage",
+                "I_Status",
+                "I_Status_Vendor",
             ]
             uint16_data = (
                 inverter_data.registers[0:6]
@@ -1101,6 +1103,7 @@ class SolarEdgeInverter:
                 + [inverter_data.registers[16]]
                 + inverter_data.registers[26:28]
                 + [inverter_data.registers[29]]
+                + inverter_data.registers[38:40]
             )
             self.decoded_model = dict(
                 zip(
@@ -1134,15 +1137,13 @@ class SolarEdgeInverter:
                 "I_Temp_Trns",
                 "I_Temp_Other",
                 "I_Temp_SF",
-                "I_Status",
-                "I_Status_Vendor",
             ]
             int16_data = (
                 [inverter_data.registers[6]]
                 + inverter_data.registers[13:16]
                 + inverter_data.registers[17:24]
                 + [inverter_data.registers[28]]
-                + inverter_data.registers[30:40]
+                + inverter_data.registers[30:38]
             )
 
             self.decoded_model.update(

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1328,7 +1328,7 @@ class SolarEdgeInverterStatus(SolarEdgeStatusSensor):
     @property
     def native_value(self):
         try:
-            if self._platform.decoded_model["I_Status"] == SunSpecNotImpl.INT16:
+            if self._platform.decoded_model["I_Status"] == SunSpecNotImpl.UINT16:
                 return None
 
             return str(DEVICE_STATUS[self._platform.decoded_model["I_Status"]])
@@ -1410,7 +1410,7 @@ class StatusVendor(SolarEdgeSensorBase):
     @property
     def native_value(self):
         try:
-            if self._platform.decoded_model["I_Status_Vendor"] == SunSpecNotImpl.INT16:
+            if self._platform.decoded_model["I_Status_Vendor"] == SunSpecNotImpl.UINT16:
                 return None
 
             else:


### PR DESCRIPTION
## Summary

`I_Status` (address 40107) and `I_Status_Vendor` (address 40108) are decoded as `int16` in hub.py but are defined as `uint16` in the SolarEdge SunSpec Implementation Technical Note.

## Spec reference

See SolarEdge Sunspec Implementation Technical Note  v3.2 (June 2025) shows both registers typed as `uint16` below:

<img width="1288" height="691" alt="image" src="https://github.com/user-attachments/assets/4ae214eb-69b0-436c-9b0a-27affb384d4d" />

## Changes

**hub.py:** Move `I_Status` and `I_Status_Vendor` from the `int16` decode list to the `uint16` decode list.

**sensor.py + const.py:** Update the not-implemented sentinel checks in `SolarEdgeInverterStatus.native_value` and `StatusVendor.native_value` from `SunSpecNotImpl.INT16` to `SunSpecNotImpl.UINT16`. Also updates the `VENDOR_STATUS` dict key in `const.py` to match.
## Testing

Tested on SE7600, firmware `0003.2537` (≥ 3.20.xx), single inverter. 
Integration loaded cleanly, `I_Status` decoded correctly
(status 4, Production), no errors in logs.