### PR TITLE
Fix inverter status text descriptions to match SunSpec spec v3.2

### DIFF
--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -225,12 +225,12 @@ DEVICE_STATUS = {
 DEVICE_STATUS_TEXT = {
     1: "Off",
     2: "Sleeping (Auto-Shutdown)",
-    3: "Grid Monitoring",
+    3: "Grid Monitoring / Wake-Up",
     4: "Production",
     5: "Production (Curtailed)",
     6: "Shutting Down",
     7: "Fault",
-    8: "Maintenance",
+    8: "Maintenance / Setup",
 }
 
 VENDOR_STATUS = {


### PR DESCRIPTION
SunSpec implementation technical note (v3.2, June 2025) defines:
  I_STATUS_STARTING (3): "Grid Monitoring / wake-up"
  I_STATUS_STANDBY  (8): "Maintenance / setup"

The previous strings "Grid Monitoring" and "Maintenance" were incomplete. Updated to match the spec descriptions exactly.