### PR TITLE
Update README: document scan options and add network security note

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This integration provides Modbus/TCP local polling to one or more SolarEdge inve
 - Automatically detects meters and batteries.
 - Supports Three Phase Inverters with Synergy Technology.
 - Polling frequency configuration option (1 to 86400 seconds).
-- Configurable starting inverter device ID.
+- Auto-discovers inverters via Fast Scan (IDs 1–32), Complete Scan (IDs 1–247), or manual device ID list.
 - Connects locally using Modbus/TCP - no cloud dependencies.
 - Informational sensor for device and its attributes
 - Supports status and error reporting sensors.
@@ -42,6 +42,14 @@ Inverter site limit and battery storage controls are disabled by default: not al
 ### Documentation
 
 [WillCodeForCats/solaredge-modbus-multi/wiki](https://github.com/WillCodeForCats/solaredge-modbus-multi/wiki)
+
+### Network Security
+
+Modbus/TCP has no built-in authentication or encryption. **All communication with the inverter is plaintext and unauthenticated.** Anyone with TCP access to the inverter's Modbus port can read register data or send control commands — including power limits, storage modes, and site limits.
+
+**Required:** The inverter's Modbus port should be firewalled so only the Home Assistant host can reach it. Do not expose the Modbus port to an untrusted network segment.
+
+Enabling Power Control Options (storage control, site limit control) on an inverter reachable by untrusted hosts is a safety risk.
 
 ### Minimum Required Versions
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,6 @@ Inverter site limit and battery storage controls are disabled by default: not al
 
 [WillCodeForCats/solaredge-modbus-multi/wiki](https://github.com/WillCodeForCats/solaredge-modbus-multi/wiki)
 
-### Network Security
-
-Modbus/TCP has no built-in authentication or encryption. **All communication with the inverter is plaintext and unauthenticated.** Anyone with TCP access to the inverter's Modbus port can read register data or send control commands — including power limits, storage modes, and site limits.
-
-**Required:** The inverter's Modbus port should be firewalled so only the Home Assistant host can reach it. Do not expose the Modbus port to an untrusted network segment.
-
-Enabling Power Control Options (storage control, site limit control) on an inverter reachable by untrusted hosts is a safety risk.
-
 ### Minimum Required Versions
 
 - Home Assistant 2025.2.0 (HA=>2025.9.0 requires release v3.1.7 or newer)


### PR DESCRIPTION
Replace stale "Configurable starting inverter device ID" bullet with description of the auto-scan and manual setup options added in the scan-for-inverters feature.

Add Network Security section noting Modbus/TCP has no authentication and the inverter port should be firewalled from untrusted networks.