### PR TITLE
Add flow dialog for batteries and controls

### DIFF
--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -75,6 +75,7 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._scan_task = None
         self._scan_user_input = None
         self._scan_task_result = None
+        self._pending_entry = None
 
     @staticmethod
     @callback
@@ -240,10 +241,12 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if self._scan_user_input is None:
                 raise AbortFlow("No scan data available")
 
-            return self.async_create_entry(
-                title=self._scan_user_input[CONF_NAME],
-                data=self._scan_user_input,
-            )
+            self._pending_entry = {
+                "title": self._scan_user_input[CONF_NAME],
+                "data": self._scan_user_input,
+            }
+
+            return await self.async_step_features_info()
 
         except Exception as e:
             raise AbortFlow(f"Scan failed: {e}")
@@ -316,9 +319,12 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                         self._abort_if_unique_id_configured()
 
-                        return self.async_create_entry(
-                            title=user_input[CONF_NAME], data=user_input
-                        )
+                        self._pending_entry = {
+                            "title": user_input[CONF_NAME],
+                            "data": user_input,
+                        }
+
+                        return await self.async_step_features_info()
 
                 finally:
                     await scanner.disconnect()
@@ -348,6 +354,21 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             ),
             errors=errors,
+        )
+
+    async def async_step_features_info(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Inform the user that batteries and controls are opt-in after setup."""
+        if user_input is not None:
+            entry = self._pending_entry
+            self._pending_entry = None
+
+            return self.async_create_entry(title=entry["title"], data=entry["data"])
+
+        return self.async_show_form(
+            step_id="features_info",
+            data_schema=vol.Schema({}),
         )
 
     async def async_step_reconfigure(

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -36,7 +36,7 @@
       },
       "features_info": {
         "title": "Batteries and Controls Are Not Enabled Yet",
-        "description": "By default, only officially documented SolarEdge features are enabled: inverters, synergy inverters, and meters.\n\nBattery monitoring and all read/write control features (battery control, site limit control) are based on documentation that SolarEdge does not publish. These are disabled by default and must be turned on separately from the integration's Configure options after this hub is added."
+        "description": "By default, only officially documented SolarEdge features are enabled: inverters, synergy inverters, and meters.\n\nBattery monitoring and all read/write control features (battery control, site limit control) are based on documentation that SolarEdge does not publish. These are disabled by default and must be turned on separately from the integration's Configure options after this hub is added.\n\nNot all inverters support these over Modbus. You may need to contact SolarEdge support to have battery and control access exposed on your installation."
       },
       "reconfigure": {
         "title": "SolarEdge Modbus Configuration",

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -34,6 +34,10 @@
       "scan_complete": {
         "title": "Scan Complete"
       },
+      "features_info": {
+        "title": "Batteries and Controls Are Not Enabled Yet",
+        "description": "By default, only officially documented SolarEdge features are enabled: inverters, synergy inverters, and meters.\n\nBattery monitoring and all read/write control features (battery control, site limit control) are based on documentation that SolarEdge does not publish. These are disabled by default and must be turned on separately from the integration's Configure options after this hub is added."
+      },
       "reconfigure": {
         "title": "SolarEdge Modbus Configuration",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -34,6 +34,10 @@
       "scan_complete": {
         "title": "Scan abgeschlossen"
       },
+      "features_info": {
+        "title": "Batterien und Steuerungen sind noch nicht aktiviert",
+        "description": "Standardmäßig sind nur offiziell von SolarEdge dokumentierte Funktionen aktiviert: Wechselrichter, Synergy-Wechselrichter und Zähler.\n\nDie Batterieüberwachung und alle Lese-/Schreibsteuerungsfunktionen (Batteriesteuerung, Standortlimitsteuerung) basieren auf Dokumentation, die SolarEdge nicht veröffentlicht. Diese sind standardmäßig deaktiviert und müssen nach dem Hinzufügen dieses Hubs separat über die Konfigurationsoptionen der Integration aktiviert werden."
+      },
       "reconfigure": {
         "title": "SolarEdge Modbus-Konfiguration",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -36,7 +36,7 @@
       },
       "features_info": {
         "title": "Batterien und Steuerungen sind noch nicht aktiviert",
-        "description": "Standardmäßig sind nur offiziell von SolarEdge dokumentierte Funktionen aktiviert: Wechselrichter, Synergy-Wechselrichter und Zähler.\n\nDie Batterieüberwachung und alle Lese-/Schreibsteuerungsfunktionen (Batteriesteuerung, Standortlimitsteuerung) basieren auf Dokumentation, die SolarEdge nicht veröffentlicht. Diese sind standardmäßig deaktiviert und müssen nach dem Hinzufügen dieses Hubs separat über die Konfigurationsoptionen der Integration aktiviert werden."
+        "description": "Standardmäßig sind nur offiziell von SolarEdge dokumentierte Funktionen aktiviert: Wechselrichter, Synergy-Wechselrichter und Zähler.\n\nDie Batterieüberwachung und alle Lese-/Schreibsteuerungsfunktionen (Batteriesteuerung, Standortlimitsteuerung) basieren auf Dokumentation, die SolarEdge nicht veröffentlicht. Diese sind standardmäßig deaktiviert und müssen nach dem Hinzufügen dieses Hubs separat über die Konfigurationsoptionen der Integration aktiviert werden.\n\nNicht alle Wechselrichter unterstützen diese Funktionen über Modbus. Sie müssen sich möglicherweise an den SolarEdge-Support wenden, um den Zugriff auf Batterie- und Steuerungsfunktionen für Ihre Anlage freischalten zu lassen."
       },
       "reconfigure": {
         "title": "SolarEdge Modbus-Konfiguration",

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -36,7 +36,7 @@
       },
       "features_info": {
         "title": "Batteries and Controls Are Not Enabled Yet",
-        "description": "By default, only officially documented SolarEdge features are enabled: inverters, synergy inverters, and meters.\n\nBattery monitoring and all read/write control features (battery control, site limit control) are based on documentation that SolarEdge does not publish. These are disabled by default and must be turned on separately from the integration's Configure options after this hub is added."
+        "description": "By default, only officially documented SolarEdge features are enabled: inverters, synergy inverters, and meters.\n\nBattery monitoring and all read/write control features (battery control, site limit control) are based on documentation that SolarEdge does not publish. These are disabled by default and must be turned on separately from the integration's Configure options after this hub is added.\n\nNot all inverters support these over Modbus. You may need to contact SolarEdge support to have battery and control access exposed on your installation."
       },
       "reconfigure": {
         "title": "SolarEdge Modbus Configuration",

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -34,6 +34,10 @@
       "scan_complete": {
         "title": "Scan Complete"
       },
+      "features_info": {
+        "title": "Batteries and Controls Are Not Enabled Yet",
+        "description": "By default, only officially documented SolarEdge features are enabled: inverters, synergy inverters, and meters.\n\nBattery monitoring and all read/write control features (battery control, site limit control) are based on documentation that SolarEdge does not publish. These are disabled by default and must be turned on separately from the integration's Configure options after this hub is added."
+      },
       "reconfigure": {
         "title": "SolarEdge Modbus Configuration",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/fr.json
+++ b/custom_components/solaredge_modbus_multi/translations/fr.json
@@ -34,6 +34,10 @@
       "scan_complete": {
         "title": "Scan terminé"
       },
+      "features_info": {
+        "title": "Les batteries et les contrôles ne sont pas encore activés",
+        "description": "Par défaut, seules les fonctionnalités officiellement documentées par SolarEdge sont activées : onduleurs, onduleurs Synergy et compteurs.\n\nLa surveillance des batteries et toutes les fonctionnalités de contrôle en lecture/écriture (contrôle des batteries, contrôle de la limite du site) reposent sur une documentation que SolarEdge ne publie pas. Elles sont désactivées par défaut et doivent être activées séparément depuis les options de configuration de l'intégration après l'ajout de ce hub."
+      },
       "reconfigure": {
         "title": "Configuration SolarEdge Modbus",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/fr.json
+++ b/custom_components/solaredge_modbus_multi/translations/fr.json
@@ -36,7 +36,7 @@
       },
       "features_info": {
         "title": "Les batteries et les contrôles ne sont pas encore activés",
-        "description": "Par défaut, seules les fonctionnalités officiellement documentées par SolarEdge sont activées : onduleurs, onduleurs Synergy et compteurs.\n\nLa surveillance des batteries et toutes les fonctionnalités de contrôle en lecture/écriture (contrôle des batteries, contrôle de la limite du site) reposent sur une documentation que SolarEdge ne publie pas. Elles sont désactivées par défaut et doivent être activées séparément depuis les options de configuration de l'intégration après l'ajout de ce hub."
+        "description": "Par défaut, seules les fonctionnalités officiellement documentées par SolarEdge sont activées : onduleurs, onduleurs Synergy et compteurs.\n\nLa surveillance des batteries et toutes les fonctionnalités de contrôle en lecture/écriture (contrôle des batteries, contrôle de la limite du site) reposent sur une documentation que SolarEdge ne publie pas. Elles sont désactivées par défaut et doivent être activées séparément depuis les options de configuration de l'intégration après l'ajout de ce hub.\n\nTous les onduleurs ne prennent pas en charge ces fonctionnalités via Modbus. Vous devrez peut-être contacter le support SolarEdge pour faire activer l'accès aux batteries et aux contrôles sur votre installation."
       },
       "reconfigure": {
         "title": "Configuration SolarEdge Modbus",

--- a/custom_components/solaredge_modbus_multi/translations/it.json
+++ b/custom_components/solaredge_modbus_multi/translations/it.json
@@ -34,6 +34,10 @@
       "scan_complete": {
         "title": "Scansione completata"
       },
+      "features_info": {
+        "title": "Batterie e controlli non sono ancora abilitati",
+        "description": "Per impostazione predefinita, sono abilitate solo le funzionalità ufficialmente documentate da SolarEdge: inverter, inverter Synergy e contatori.\n\nIl monitoraggio della batteria e tutte le funzionalità di controllo in lettura/scrittura (controllo della batteria, controllo del limite del sito) si basano su documentazione non pubblicata da SolarEdge. Queste funzionalità sono disabilitate per impostazione predefinita e devono essere attivate separatamente dalle opzioni di configurazione dell'integrazione dopo l'aggiunta di questo hub."
+      },
       "reconfigure": {
         "title": "Configurazione Modbus SolarEdge",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/it.json
+++ b/custom_components/solaredge_modbus_multi/translations/it.json
@@ -36,7 +36,7 @@
       },
       "features_info": {
         "title": "Batterie e controlli non sono ancora abilitati",
-        "description": "Per impostazione predefinita, sono abilitate solo le funzionalità ufficialmente documentate da SolarEdge: inverter, inverter Synergy e contatori.\n\nIl monitoraggio della batteria e tutte le funzionalità di controllo in lettura/scrittura (controllo della batteria, controllo del limite del sito) si basano su documentazione non pubblicata da SolarEdge. Queste funzionalità sono disabilitate per impostazione predefinita e devono essere attivate separatamente dalle opzioni di configurazione dell'integrazione dopo l'aggiunta di questo hub."
+        "description": "Per impostazione predefinita, sono abilitate solo le funzionalità ufficialmente documentate da SolarEdge: inverter, inverter Synergy e contatori.\n\nIl monitoraggio della batteria e tutte le funzionalità di controllo in lettura/scrittura (controllo della batteria, controllo del limite del sito) si basano su documentazione non pubblicata da SolarEdge. Queste funzionalità sono disabilitate per impostazione predefinita e devono essere attivate separatamente dalle opzioni di configurazione dell'integrazione dopo l'aggiunta di questo hub.\n\nNon tutti gli inverter supportano queste funzionalità tramite Modbus. Potrebbe essere necessario contattare l'assistenza SolarEdge per far abilitare l'accesso a batteria e controlli sul proprio impianto."
       },
       "reconfigure": {
         "title": "Configurazione Modbus SolarEdge",

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -34,6 +34,10 @@
       "scan_complete": {
         "title": "Skanning fullført"
       },
+      "features_info": {
+        "title": "Batterier og kontroller er ikke aktivert ennå",
+        "description": "Som standard er kun offisielt dokumenterte SolarEdge-funksjoner aktivert: vekselrettere, Synergy-vekselrettere og målere.\n\nBatteriovervåking og alle lese-/skrivekontrollfunksjoner (batterikontroll, stedsgrensekontroll) er basert på dokumentasjon som SolarEdge ikke publiserer. Disse er deaktivert som standard og må aktiveres separat fra integrasjonens konfigurasjonsalternativer etter at denne huben er lagt til."
+      },
       "reconfigure": {
         "title": "SolarEdge Modbus-konfigurasjon",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -36,7 +36,7 @@
       },
       "features_info": {
         "title": "Batterier og kontroller er ikke aktivert ennå",
-        "description": "Som standard er kun offisielt dokumenterte SolarEdge-funksjoner aktivert: vekselrettere, Synergy-vekselrettere og målere.\n\nBatteriovervåking og alle lese-/skrivekontrollfunksjoner (batterikontroll, stedsgrensekontroll) er basert på dokumentasjon som SolarEdge ikke publiserer. Disse er deaktivert som standard og må aktiveres separat fra integrasjonens konfigurasjonsalternativer etter at denne huben er lagt til."
+        "description": "Som standard er kun offisielt dokumenterte SolarEdge-funksjoner aktivert: vekselrettere, Synergy-vekselrettere og målere.\n\nBatteriovervåking og alle lese-/skrivekontrollfunksjoner (batterikontroll, stedsgrensekontroll) er basert på dokumentasjon som SolarEdge ikke publiserer. Disse er deaktivert som standard og må aktiveres separat fra integrasjonens konfigurasjonsalternativer etter at denne huben er lagt til.\n\nIkke alle vekselrettere støtter dette over Modbus. Du må kanskje kontakte SolarEdge-support for å få tilgang til batteri- og kontrollfunksjoner aktivert på anlegget ditt."
       },
       "reconfigure": {
         "title": "SolarEdge Modbus-konfigurasjon",

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -34,6 +34,10 @@
       "scan_complete": {
         "title": "Scan voltooid"
       },
+      "features_info": {
+        "title": "Batterijen en besturingen zijn nog niet ingeschakeld",
+        "description": "Standaard zijn alleen door SolarEdge officieel gedocumenteerde functies ingeschakeld: omvormers, Synergy-omvormers en meters.\n\nBatterijbewaking en alle lees-/schrijfbesturingsfuncties (batterijbesturing, locatielimietbesturing) zijn gebaseerd op documentatie die SolarEdge niet publiceert. Deze zijn standaard uitgeschakeld en moeten na het toevoegen van deze hub apart worden ingeschakeld via de configuratieopties van de integratie."
+      },
       "reconfigure": {
         "title": "SolarEdge Modbus-configuratie",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -36,7 +36,7 @@
       },
       "features_info": {
         "title": "Batterijen en besturingen zijn nog niet ingeschakeld",
-        "description": "Standaard zijn alleen door SolarEdge officieel gedocumenteerde functies ingeschakeld: omvormers, Synergy-omvormers en meters.\n\nBatterijbewaking en alle lees-/schrijfbesturingsfuncties (batterijbesturing, locatielimietbesturing) zijn gebaseerd op documentatie die SolarEdge niet publiceert. Deze zijn standaard uitgeschakeld en moeten na het toevoegen van deze hub apart worden ingeschakeld via de configuratieopties van de integratie."
+        "description": "Standaard zijn alleen door SolarEdge officieel gedocumenteerde functies ingeschakeld: omvormers, Synergy-omvormers en meters.\n\nBatterijbewaking en alle lees-/schrijfbesturingsfuncties (batterijbesturing, locatielimietbesturing) zijn gebaseerd op documentatie die SolarEdge niet publiceert. Deze zijn standaard uitgeschakeld en moeten na het toevoegen van deze hub apart worden ingeschakeld via de configuratieopties van de integratie.\n\nNiet alle omvormers ondersteunen dit via Modbus. Mogelijk moet u contact opnemen met SolarEdge-support om toegang tot batterij- en besturingsfuncties op uw installatie te laten activeren."
       },
       "reconfigure": {
         "title": "SolarEdge Modbus-configuratie",

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -36,7 +36,7 @@
       },
       "features_info": {
         "title": "Baterie i sterowanie nie są jeszcze włączone",
-        "description": "Domyślnie włączone są tylko funkcje oficjalnie udokumentowane przez SolarEdge: falowniki, falowniki Synergy oraz liczniki.\n\nMonitorowanie baterii oraz wszystkie funkcje sterowania odczytu/zapisu (sterowanie baterią, sterowanie limitem instalacji) opierają się na dokumentacji, której SolarEdge nie publikuje. Są one domyślnie wyłączone i należy je włączyć osobno w opcjach konfiguracji integracji po dodaniu tego huba."
+        "description": "Domyślnie włączone są tylko funkcje oficjalnie udokumentowane przez SolarEdge: falowniki, falowniki Synergy oraz liczniki.\n\nMonitorowanie baterii oraz wszystkie funkcje sterowania odczytu/zapisu (sterowanie baterią, sterowanie limitem instalacji) opierają się na dokumentacji, której SolarEdge nie publikuje. Są one domyślnie wyłączone i należy je włączyć osobno w opcjach konfiguracji integracji po dodaniu tego huba.\n\nNie wszystkie falowniki obsługują to przez Modbus. Może być konieczny kontakt z pomocą techniczną SolarEdge w celu odblokowania dostępu do baterii i funkcji sterowania w Twojej instalacji."
       },
       "reconfigure": {
         "title": "Konfiguracja SolarEdge Modbus",

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -34,6 +34,10 @@
       "scan_complete": {
         "title": "Skanowanie zakończone"
       },
+      "features_info": {
+        "title": "Baterie i sterowanie nie są jeszcze włączone",
+        "description": "Domyślnie włączone są tylko funkcje oficjalnie udokumentowane przez SolarEdge: falowniki, falowniki Synergy oraz liczniki.\n\nMonitorowanie baterii oraz wszystkie funkcje sterowania odczytu/zapisu (sterowanie baterią, sterowanie limitem instalacji) opierają się na dokumentacji, której SolarEdge nie publikuje. Są one domyślnie wyłączone i należy je włączyć osobno w opcjach konfiguracji integracji po dodaniu tego huba."
+      },
       "reconfigure": {
         "title": "Konfiguracja SolarEdge Modbus",
         "data": {


### PR DESCRIPTION
Batteries and controls are disabled by default because they are not officially supported by SolarEdge over modbus.

This PR adds a dialog step telling users how to enable them after adding a hub.