### PR TITLE
Don't disconnect if a write is in process

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -425,7 +425,7 @@ class SolarEdgeModbusMultiHub:
 
             ir.async_delete_issue(self._hass, DOMAIN, "check_configuration")
 
-            if not self.keep_modbus_open:
+            if not self.keep_modbus_open and not self.has_write:
                 await self.disconnect()
 
             return True
@@ -497,7 +497,7 @@ class SolarEdgeModbusMultiHub:
             )
             self._timeout_counter = 0
 
-        if not self.keep_modbus_open:
+        if not self.keep_modbus_open and not self.has_write:
             await self.disconnect()
 
         return True


### PR DESCRIPTION
Check the `has_write` flag together with `keep_modbus_open` when calling normal disconnect.

Fix recommended in issue #1025 by @tieskuh