### PR TITLE
Skip invalid Device  ID during setup

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -281,6 +281,12 @@ class SolarEdgeModbusMultiHub:
                 await new_inverter.init_device()
                 self.inverters.append(new_inverter)
 
+                ir.async_delete_issue(
+                    self._hass,
+                    DOMAIN,
+                    self._setup_inverter_id_failed_issue(inverter_unit_id),
+                )
+
             except (ModbusReadError, TimeoutError) as e:
                 await self.disconnect()
                 raise HubInitFailed(f"{e}")

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -388,6 +388,14 @@ class SolarEdgeModbusMultiHub:
                         _LOGGER.debug(f"I{inverter_unit_id}B{battery_id}: {e}")
                         pass
 
+        if not self.inverters:
+            # fail the hub setup if there are no inverters
+            await self.disconnect()
+            raise HubInitFailed(
+                f"No usable inverters found at {self.hub_host} for configured "
+                "Device ID(s). Check the repair issue(s) for details."
+            )
+
         try:
             for inverter in self.inverters:
                 await inverter.read_modbus_data()

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -286,9 +286,23 @@ class SolarEdgeModbusMultiHub:
                 raise HubInitFailed(f"{e}")
 
             except DeviceInvalid as e:
-                # Inverters are mandatory
+                # Inverters are mandatory, but if the Device ID is invalid or not responding
+                # skip it and warn the user instead of failing the entire hub setup
                 _LOGGER.error(f"Inverter at {self.hub_host} ID {inverter_unit_id}: {e}")
-                raise HubInitFailed(f"{e}")
+                ir.async_create_issue(
+                    self._hass,
+                    DOMAIN,
+                    self._setup_inverter_id_failed_issue(inverter_unit_id),
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.ERROR,
+                    translation_key="setup_inverter_id_failed",
+                    translation_placeholders={
+                        "device_id": str(inverter_unit_id),
+                        "host": self.hub_host,
+                    },
+                    data={"entry_id": self._entry_id},
+                )
+                continue
 
             except DeviceIsEVSE as e:
                 _LOGGER.debug(
@@ -699,6 +713,9 @@ class SolarEdgeModbusMultiHub:
 
             await self.disconnect()
             raise ModbusWriteError(result)
+
+    def _setup_inverter_id_failed_issue(self, unit_id: int) -> str:
+        return f"setup_inverter_id_failed_{self._entry_id}_{unit_id}"
 
     @staticmethod
     def _safe_version_tuple(version_str: str) -> tuple[int, ...]:

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -994,8 +994,8 @@ class SolarEdgeInverter:
 
             self.hub.inverter_common[self.inverter_unit_id] = self.decoded_common
 
-        except ModbusIOError:
-            raise DeviceInvalid(f"No response from inverter ID {self.inverter_unit_id}")
+        except (ModbusIOError, ModbusIOException):
+            raise DeviceInvalid(f"No response from Device ID {self.inverter_unit_id}")
 
         except ModbusIllegalAddress:
             raise DeviceInvalid(

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -126,6 +126,10 @@
         }
       }
     },
+    "setup_inverter_id_failed": {
+      "title": "Invalid Inverter Device ID",
+      "description": "Inverter Device ID {device_id} at {host} is not responding or is not a valid SolarEdge inverter. It has been skipped. If the device was replaced or its ID changed, update the Inverter Device ID List in the hub configuration. Otherwise check the device and Modbus/TCP connection."
+    },
     "detect_timeout_gpc": {
       "title": "Global Dynamic Power Control Timeout",
       "description": "The inverter did not respond while reading data for Global Dynamic Power Controls. These entities will be unavailable. Disable the Auto-Detect Additional Entities option if the inverter has trouble trying to read these sensors."

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -127,6 +127,10 @@
         }
       }
     },
+    "setup_inverter_id_failed": {
+      "title": "Ungültige Wechselrichter-Geräte-ID",
+      "description": "Wechselrichter-Geräte-ID {device_id} bei {host} antwortet nicht oder ist kein gültiger SolarEdge-Wechselrichter. Sie wurde übersprungen. Wenn das Gerät ausgetauscht oder seine ID geändert wurde, aktualisieren Sie die Liste der Wechselrichter-Geräte-IDs in der Hub-Konfiguration. Andernfalls überprüfen Sie das Gerät und die Modbus/TCP-Verbindung."
+    },
     "detect_timeout_gpc": {
       "title": "Global Dynamic Power Control Timeout",
       "description": "Der Wechselrichter reagierte nicht beim Lesen von Daten für globale dynamische Leistungssteuerung."

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -126,6 +126,10 @@
         }
       }
     },
+    "setup_inverter_id_failed": {
+      "title": "Invalid Inverter Device ID",
+      "description": "Inverter Device ID {device_id} at {host} is not responding or is not a valid SolarEdge inverter. It has been skipped. If the device was replaced or its ID changed, update the Inverter Device ID List in the hub configuration. Otherwise check the device and Modbus/TCP connection."
+    },
     "detect_timeout_gpc": {
       "title": "Global Dynamic Power Control Timeout",
       "description": "The inverter did not respond while reading data for Global Dynamic Power Controls. These entities will be unavailable. Disable the Auto-Detect Additional Entities option if the inverter has trouble trying to read these sensors."

--- a/custom_components/solaredge_modbus_multi/translations/fr.json
+++ b/custom_components/solaredge_modbus_multi/translations/fr.json
@@ -127,6 +127,10 @@
         }
       }
     },
+    "setup_inverter_id_failed": {
+      "title": "ID d'appareil onduleur invalide",
+      "description": "L'ID d'appareil onduleur {device_id} sur {host} ne répond pas ou n'est pas un onduleur SolarEdge valide. Il a été ignoré. Si l'appareil a été remplacé ou si son ID a changé, mettez à jour la liste des ID d'appareils onduleurs dans la configuration du hub. Sinon, vérifiez l'appareil et la connexion Modbus/TCP."
+    },
     "detect_timeout_gpc": {
       "title": "Tempsion mondial de contrôle de la puissance dynamique",
       "description": "L'onduleur n'a pas répondu lors de la lecture des données pour les contrôles de puissance dynamique globaux."

--- a/custom_components/solaredge_modbus_multi/translations/it.json
+++ b/custom_components/solaredge_modbus_multi/translations/it.json
@@ -127,6 +127,10 @@
         }
       }
     },
+    "setup_inverter_id_failed": {
+      "title": "ID dispositivo inverter non valido",
+      "description": "L'ID dispositivo inverter {device_id} su {host} non risponde o non è un inverter SolarEdge valido. È stato ignorato. Se il dispositivo è stato sostituito o il suo ID è cambiato, aggiorna l'elenco degli ID dispositivo inverter nella configurazione dell'hub. Altrimenti controlla il dispositivo e la connessione Modbus/TCP."
+    },
     "detect_timeout_gpc": {
       "title": "Timeout di controllo del potere dinamico globale",
       "description": "L'inverter non ha risposto durante la lettura dei dati per i controlli di potenza dinamica globali."

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -127,6 +127,10 @@
         }
       }
     },
+    "setup_inverter_id_failed": {
+      "title": "Ugyldig omformer-enhets-ID",
+      "description": "Omformer-enhets-ID {device_id} på {host} svarer ikke eller er ikke en gyldig SolarEdge-omformer. Den er hoppet over. Hvis enheten er byttet ut eller ID-en er endret, oppdater listen over omformer-enhets-ID-er i hub-konfigurasjonen. Kontroller ellers enheten og Modbus/TCP-tilkoblingen."
+    },
     "detect_timeout_gpc": {
       "title": "Global dynamisk kraftkontroll timeout",
       "description": "Omformeren svarte ikke mens du leste data for global dynamisk kraftkontroll."

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -127,6 +127,10 @@
         }
       }
     },
+    "setup_inverter_id_failed": {
+      "title": "Ongeldige omvormer-apparaat-ID",
+      "description": "Omvormer-apparaat-ID {device_id} op {host} reageert niet of is geen geldige SolarEdge-omvormer. Deze is overgeslagen. Als het apparaat is vervangen of de ID is gewijzigd, werk dan de lijst met omvormer-apparaat-ID's bij in de hub-configuratie. Controleer anders het apparaat en de Modbus/TCP-verbinding."
+    },
     "detect_timeout_gpc": {
       "title": "Global Dynamic Power Control Time -out",
       "description": "De omvormer reageerde niet tijdens het lezen van gegevens voor Global Dynamic Power Controls."

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -127,6 +127,10 @@
         }
       }
     },
+    "setup_inverter_id_failed": {
+      "title": "Nieprawidłowy identyfikator falownika",
+      "description": "Identyfikator falownika {device_id} na {host} nie odpowiada lub nie jest prawidłowym falownikiem SolarEdge. Został pominięty. Jeśli urządzenie zostało wymienione lub jego identyfikator się zmienił, zaktualizuj listę identyfikatorów falowników w konfiguracji huba. W przeciwnym razie sprawdź urządzenie i połączenie Modbus/TCP."
+    },
     "detect_timeout_gpc": {
       "title": "Globalny limit dynamicznej kontroli mocy",
       "description": "Falownik nie zareagował podczas czytania danych dla globalnej dynamicznej kontroli mocy."


### PR DESCRIPTION
If a device ID fails to respond or otherwise raises DeviceInvalid during setup, skip that ID and raise a repair issue.