### PR TITLE
Add cabinet, transformer and other inverter temperature sensors

### DIFF
--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -91,6 +91,21 @@ async def async_setup_entry(
         entities.append(DCVoltage(inverter, config_entry, coordinator))
         entities.append(DCPower(inverter, config_entry, coordinator))
         entities.append(HeatSinkTemperature(inverter, config_entry, coordinator))
+        entities.append(
+            InverterExtraTemperature(
+                inverter, config_entry, coordinator, "Cab", "Cabinet"
+            )
+        )
+        entities.append(
+            InverterExtraTemperature(
+                inverter, config_entry, coordinator, "Trns", "Transformer"
+            )
+        )
+        entities.append(
+            InverterExtraTemperature(
+                inverter, config_entry, coordinator, "Other", "Other"
+            )
+        )
 
         if hub.option_detect_extras and inverter.global_power_control:
             entities.append(SolarEdgeRRCR(inverter, config_entry, coordinator))
@@ -1279,6 +1294,70 @@ class HeatSinkTemperature(SolarEdgeSensorBase):
 
     @property
     def suggested_display_precision(self):
+        return abs(self._platform.decoded_model["I_Temp_SF"])
+
+
+class InverterExtraTemperature(SolarEdgeSensorBase):
+    """Cabinet, transformer, or other temperature for a SolarEdge inverter.
+
+    Most inverter models implement only the heat sink temperature, so
+    these sensors are disabled by default and report None when the
+    register is not implemented.
+    """
+
+    device_class = SensorDeviceClass.TEMPERATURE
+    state_class = SensorStateClass.MEASUREMENT
+    native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    entity_category = EntityCategory.DIAGNOSTIC
+    entity_registry_enabled_default = False
+
+    def __init__(self, platform, config_entry, coordinator, sensor: str, label: str):
+        super().__init__(platform, config_entry, coordinator)
+
+        self._model_key = f"I_Temp_{sensor}"
+        self._uid_key = sensor.lower()
+        self._label = label
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_temp_{self._uid_key}"
+
+    @property
+    def name(self) -> str:
+        return f"Temperature {self._label}"
+
+    @property
+    def native_value(self):
+        try:
+            value = self._platform.decoded_model[self._model_key]
+
+            # INT16 registers are decoded signed, so the SunSpec
+            # not-implemented sentinel arrives as -32768 while
+            # SunSpecNotImpl.INT16 is 0x8000 (+32768). Mask to 16 bits so both
+            # representations are recognised; otherwise an unimplemented
+            # register is scaled and reported as -327.68 degrees.
+            if (
+                value == 0x0
+                or (value & 0xFFFF) == SunSpecNotImpl.INT16
+                or self._platform.decoded_model["I_Temp_SF"] == SunSpecNotImpl.INT16
+                or self._platform.decoded_model["I_Temp_SF"] not in SUNSPEC_SF_RANGE
+            ):
+                return None
+
+            else:
+                return self.scale_factor(
+                    value,
+                    self._platform.decoded_model["I_Temp_SF"],
+                )
+
+        except (TypeError, KeyError):
+            return None
+
+    @property
+    def suggested_display_precision(self):
+        if self._platform.decoded_model["I_Temp_SF"] not in SUNSPEC_SF_RANGE:
+            return 1
+
         return abs(self._platform.decoded_model["I_Temp_SF"])
 
 


### PR DESCRIPTION
## Proposed change

The SunSpec inverter model reads four temperature registers on every poll cycle, but only
the heat sink temperature is exposed as an entity. `I_Temp_Cab`, `I_Temp_Trns` and
`I_Temp_Other` are decoded and then discarded.

This adds them as three diagnostic sensors, disabled by default, because most inverters
implement only the heat sink value.

While testing this on my own system I found that the not-implemented check used by the
existing heat sink sensor does not actually match:

```python
self._platform.decoded_model["I_Temp_Sink"] == SunSpecNotImpl.INT16
```

`SunSpecNotImpl.INT16` is `0x8000`, i.e. **+32768**, but INT16 registers are decoded
signed, so an unimplemented register arrives as **-32768**. The comparison is therefore
never true. On the heat sink sensor this never shows, because that register is
implemented on essentially every inverter - but it is exactly the normal case for the
three registers added here.

The new sensors therefore compare the value masked to 16 bits, which matches both
representations:

```python
(value & 0xFFFF) == SunSpecNotImpl.INT16
```

I deliberately did **not** change the existing heat sink sensor in this PR, to keep it to
one subject. If you want the same correction applied to the other sensors using that
comparison, I am happy to do it as a separate PR.

## Testing

Tested on an **SE10K-RWS (48 V Home Hub)** running a current firmware.

That inverter implements only the heat sink register. Read from the running integration:

| Register | Raw value | Sensor |
|---|---|---|
| `I_Temp_Sink` | `0x0f28` | 38.8 °C |
| `I_Temp_Cab` | `-0x8000` | unknown |
| `I_Temp_Trns` | `-0x8000` | unknown |
| `I_Temp_Other` | `-0x8000` | unknown |

With the masked comparison all three new entities correctly report *unknown*. Without it
they report **-327.68 °C**, since `-32768` is passed through the scale factor - I saw that
before fixing it, which is how the sign mismatch turned up.

Verified in a running Home Assistant instance, not only in isolation: the entities were
enabled in the entity settings and read back through the API after a restart.

## Checklist

- [x] Based on the latest upstream main.
- [x] One subject only.
- [x] Tested against real hardware.
