### PR TITLE
Translate inverter and battery status states

### DIFF
--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1329,6 +1329,7 @@ class SolarEdgeStatusSensor(SolarEdgeSensorBase):
 
 class SolarEdgeInverterStatus(SolarEdgeStatusSensor):
     options = list(DEVICE_STATUS.values())
+    _attr_translation_key = "inverter_status"
 
     @property
     def native_value(self):
@@ -1364,6 +1365,7 @@ class SolarEdgeInverterStatus(SolarEdgeStatusSensor):
 
 class SolarEdgeBatteryStatus(SolarEdgeStatusSensor):
     options = list(BATTERY_STATUS.values())
+    _attr_translation_key = "battery_status"
 
     @property
     def native_value(self):

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -143,5 +143,34 @@
       "title": "Fortgeschrittene Leistungssteuerung Zeitlimit",
       "description": "Der Wechselrichter reagierte nicht beim Lesen von Daten für fortgeschrittene Stromversorgungssteuerungen."
     }
+  },
+  "entity": {
+    "sensor": {
+      "inverter_status": {
+        "state": {
+          "I_STATUS_OFF": "Aus",
+          "I_STATUS_SLEEPING": "Ruhezustand (automatische Abschaltung)",
+          "I_STATUS_STARTING": "Netzprüfung",
+          "I_STATUS_MPPT": "Erzeugung",
+          "I_STATUS_THROTTLED": "Erzeugung (abgeregelt)",
+          "I_STATUS_SHUTTING_DOWN": "Herunterfahren",
+          "I_STATUS_FAULT": "Störung",
+          "I_STATUS_STANDBY": "Wartung"
+        }
+      },
+      "battery_status": {
+        "state": {
+          "B_STATUS_OFF": "Aus",
+          "B_STATUS_STANDBY": "Bereitschaft",
+          "B_STATUS_INIT": "Initialisierung",
+          "B_STATUS_CHARGE": "Lädt",
+          "B_STATUS_DISCHARGE": "Entlädt",
+          "B_STATUS_FAULT": "Störung",
+          "B_STATUS_PRESERVE_CHARGE": "Ladung halten",
+          "B_STATUS_IDLE": "Leerlauf",
+          "B_STATUS_POWER_SAVING": "Energiesparmodus"
+        }
+      }
+    }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -142,5 +142,34 @@
       "title": "Advanced Power Control Timeout",
       "description": "The inverter did not respond while reading data for Advanced Power Controls. These entities will be unavailable. Disable the Auto-Detect Additional Entities option if the inverter has trouble trying to read these sensors."
     }
+  },
+  "entity": {
+    "sensor": {
+      "inverter_status": {
+        "state": {
+          "I_STATUS_OFF": "Off",
+          "I_STATUS_SLEEPING": "Sleeping (Auto-Shutdown)",
+          "I_STATUS_STARTING": "Grid Monitoring",
+          "I_STATUS_MPPT": "Production",
+          "I_STATUS_THROTTLED": "Production (Curtailed)",
+          "I_STATUS_SHUTTING_DOWN": "Shutting Down",
+          "I_STATUS_FAULT": "Fault",
+          "I_STATUS_STANDBY": "Maintenance"
+        }
+      },
+      "battery_status": {
+        "state": {
+          "B_STATUS_OFF": "Off",
+          "B_STATUS_STANDBY": "Standby",
+          "B_STATUS_INIT": "Initializing",
+          "B_STATUS_CHARGE": "Charge",
+          "B_STATUS_DISCHARGE": "Discharge",
+          "B_STATUS_FAULT": "Fault",
+          "B_STATUS_PRESERVE_CHARGE": "Preserve Charge",
+          "B_STATUS_IDLE": "Idle",
+          "B_STATUS_POWER_SAVING": "Power Saving"
+        }
+      }
+    }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/fr.json
+++ b/custom_components/solaredge_modbus_multi/translations/fr.json
@@ -143,5 +143,34 @@
       "title": "Timeout de contrôle de puissance avancé",
       "description": "L'onduleur n'a pas répondu lors de la lecture des données pour les contrôles de puissance avancés."
     }
+  },
+  "entity": {
+    "sensor": {
+      "inverter_status": {
+        "state": {
+          "I_STATUS_OFF": "Arrêt",
+          "I_STATUS_SLEEPING": "Veille (arrêt automatique)",
+          "I_STATUS_STARTING": "Surveillance du réseau",
+          "I_STATUS_MPPT": "Production",
+          "I_STATUS_THROTTLED": "Production (limitée)",
+          "I_STATUS_SHUTTING_DOWN": "Arrêt en cours",
+          "I_STATUS_FAULT": "Défaut",
+          "I_STATUS_STANDBY": "Maintenance"
+        }
+      },
+      "battery_status": {
+        "state": {
+          "B_STATUS_OFF": "Arrêt",
+          "B_STATUS_STANDBY": "Veille",
+          "B_STATUS_INIT": "Initialisation",
+          "B_STATUS_CHARGE": "Charge",
+          "B_STATUS_DISCHARGE": "Décharge",
+          "B_STATUS_FAULT": "Défaut",
+          "B_STATUS_PRESERVE_CHARGE": "Maintien de charge",
+          "B_STATUS_IDLE": "Inactif",
+          "B_STATUS_POWER_SAVING": "Économie d'énergie"
+        }
+      }
+    }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/it.json
+++ b/custom_components/solaredge_modbus_multi/translations/it.json
@@ -143,5 +143,34 @@
       "title": "Timeout di controllo del potere avanzato",
       "description": "L'inverter non ha risposto durante la lettura dei dati per i controlli di potenza avanzati."
     }
+  },
+  "entity": {
+    "sensor": {
+      "inverter_status": {
+        "state": {
+          "I_STATUS_OFF": "Spento",
+          "I_STATUS_SLEEPING": "Standby (spegnimento automatico)",
+          "I_STATUS_STARTING": "Monitoraggio della rete",
+          "I_STATUS_MPPT": "Produzione",
+          "I_STATUS_THROTTLED": "Produzione (limitata)",
+          "I_STATUS_SHUTTING_DOWN": "Arresto in corso",
+          "I_STATUS_FAULT": "Guasto",
+          "I_STATUS_STANDBY": "Manutenzione"
+        }
+      },
+      "battery_status": {
+        "state": {
+          "B_STATUS_OFF": "Spento",
+          "B_STATUS_STANDBY": "Standby",
+          "B_STATUS_INIT": "Inizializzazione",
+          "B_STATUS_CHARGE": "Carica",
+          "B_STATUS_DISCHARGE": "Scarica",
+          "B_STATUS_FAULT": "Guasto",
+          "B_STATUS_PRESERVE_CHARGE": "Mantenimento della carica",
+          "B_STATUS_IDLE": "Inattivo",
+          "B_STATUS_POWER_SAVING": "Risparmio energetico"
+        }
+      }
+    }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -143,5 +143,34 @@
       "title": "Avansert timeout for strømkontroll",
       "description": "Omformeren svarte ikke mens du leste data for avanserte strømkontroller."
     }
+  },
+  "entity": {
+    "sensor": {
+      "inverter_status": {
+        "state": {
+          "I_STATUS_OFF": "Av",
+          "I_STATUS_SLEEPING": "Hvilemodus (automatisk avslåing)",
+          "I_STATUS_STARTING": "Nettovervåking",
+          "I_STATUS_MPPT": "Produksjon",
+          "I_STATUS_THROTTLED": "Produksjon (begrenset)",
+          "I_STATUS_SHUTTING_DOWN": "Slår av",
+          "I_STATUS_FAULT": "Feil",
+          "I_STATUS_STANDBY": "Vedlikehold"
+        }
+      },
+      "battery_status": {
+        "state": {
+          "B_STATUS_OFF": "Av",
+          "B_STATUS_STANDBY": "Hvilemodus",
+          "B_STATUS_INIT": "Initialiserer",
+          "B_STATUS_CHARGE": "Lader",
+          "B_STATUS_DISCHARGE": "Utlader",
+          "B_STATUS_FAULT": "Feil",
+          "B_STATUS_PRESERVE_CHARGE": "Bevarer ladning",
+          "B_STATUS_IDLE": "Inaktiv",
+          "B_STATUS_POWER_SAVING": "Strømsparing"
+        }
+      }
+    }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -143,5 +143,34 @@
       "title": "Geavanceerde time -out voor stroomregeling",
       "description": "De omvormer reageerde niet tijdens het lezen van gegevens voor geavanceerde stroomregeling."
     }
+  },
+  "entity": {
+    "sensor": {
+      "inverter_status": {
+        "state": {
+          "I_STATUS_OFF": "Uit",
+          "I_STATUS_SLEEPING": "Slaapstand (automatisch uitschakelen)",
+          "I_STATUS_STARTING": "Netbewaking",
+          "I_STATUS_MPPT": "Productie",
+          "I_STATUS_THROTTLED": "Productie (beperkt)",
+          "I_STATUS_SHUTTING_DOWN": "Afsluiten",
+          "I_STATUS_FAULT": "Storing",
+          "I_STATUS_STANDBY": "Onderhoud"
+        }
+      },
+      "battery_status": {
+        "state": {
+          "B_STATUS_OFF": "Uit",
+          "B_STATUS_STANDBY": "Stand-by",
+          "B_STATUS_INIT": "Initialiseren",
+          "B_STATUS_CHARGE": "Laden",
+          "B_STATUS_DISCHARGE": "Ontladen",
+          "B_STATUS_FAULT": "Storing",
+          "B_STATUS_PRESERVE_CHARGE": "Lading behouden",
+          "B_STATUS_IDLE": "Inactief",
+          "B_STATUS_POWER_SAVING": "Energiebesparing"
+        }
+      }
+    }
   }
 }

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -143,5 +143,34 @@
       "title": "Zaawansowany limit czasu kontroli mocy",
       "description": "Falownik nie zareagował podczas czytania danych pod kątem zaawansowanych kontroli mocy."
     }
+  },
+  "entity": {
+    "sensor": {
+      "inverter_status": {
+        "state": {
+          "I_STATUS_OFF": "Wyłączony",
+          "I_STATUS_SLEEPING": "Czuwanie (automatyczne wyłączenie)",
+          "I_STATUS_STARTING": "Monitorowanie sieci",
+          "I_STATUS_MPPT": "Produkcja",
+          "I_STATUS_THROTTLED": "Produkcja (ograniczona)",
+          "I_STATUS_SHUTTING_DOWN": "Wyłączanie",
+          "I_STATUS_FAULT": "Awaria",
+          "I_STATUS_STANDBY": "Konserwacja"
+        }
+      },
+      "battery_status": {
+        "state": {
+          "B_STATUS_OFF": "Wyłączony",
+          "B_STATUS_STANDBY": "Czuwanie",
+          "B_STATUS_INIT": "Inicjalizacja",
+          "B_STATUS_CHARGE": "Ładowanie",
+          "B_STATUS_DISCHARGE": "Rozładowywanie",
+          "B_STATUS_FAULT": "Awaria",
+          "B_STATUS_PRESERVE_CHARGE": "Utrzymanie ładunku",
+          "B_STATUS_IDLE": "Bezczynny",
+          "B_STATUS_POWER_SAVING": "Oszczędzanie energii"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Proposed change

Both status sensors are already `SensorDeviceClass.ENUM` with `options`, and the integration ships translations for the config flow, options and repair issues. The **entity states** however are not translated, so the UI shows the raw option, for example `B_STATUS_PRESERVE_CHARGE` or `I_STATUS_MPPT`.

The readable text already exists in the integration - `DEVICE_STATUS_TEXT` and `BATTERY_STATUS_TEXT` are exposed as a `status_text` attribute - but attributes are not shown on the device page, so what a user actually reads is the raw constant.

This adds a `translation_key` to both status sensors and the corresponding `entity.sensor.*.state` sections, covering all 8 inverter and all 9 battery states.

**Updated for review:** all seven shipped languages are now filled in together - `en`, `de`, `fr`, `it`, `nb`, `nl`, `pl`. The first version only had `en` and `de`; that was wrong for this project and is fixed.

English reuses the existing wording from the two `*_TEXT` tables so there is only one set of terms in the project. I can verify `en`, `de` and `fr` myself; `it`, `nb`, `nl` and `pl` are my best effort from the English terms, so corrections from native speakers are welcome for those four.

**This is not a breaking change.** The state value is untouched, only the displayed text changes, so automations and templates comparing against `B_STATUS_*` or `I_STATUS_*` keep working.

## Testing

Tested on a running Home Assistant instance with an inverter and a battery.

Registry after the change:

```
sensor.<inverter>_status      translation_key=inverter_status
sensor.<inverter>_b1_status   translation_key=battery_status
```

Translations served by the frontend API:

```
[de] B_STATUS_PRESERVE_CHARGE -> Ladung halten     [en] -> Preserve Charge
[de] I_STATUS_MPPT            -> Erzeugung         [en] -> Production
```

Two things I checked explicitly because they were the risk:

- **State values unchanged.** The sensors still report `B_STATUS_DISCHARGE` and `I_STATUS_MPPT` through the API after the change.
- **Entity names unchanged.** Setting a translation key can take over the entity name; it does not here, because both classes define `name` as a property.

Rebased on the current main.

## Checklist

- [x] Based on the latest upstream main.
- [x] One subject only.
- [x] Tested on a running instance.
