### PR TITLE
Add missing f-prefixes to write error messages

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -699,7 +699,7 @@ class SolarEdgeModbusMultiHub:
                     f"Write failed: No response from inverter ID {self._wr_unit}."
                 )
                 raise HomeAssistantError(
-                    "No response from inverter ID {self._wr_unit}."
+                    f"No response from inverter ID {self._wr_unit}."
                 )
 
             if type(result) is ExceptionResponse:
@@ -708,7 +708,7 @@ class SolarEdgeModbusMultiHub:
                         f"Unit {self._wr_unit} Write IllegalAddress: {result}"
                     )
                     raise HomeAssistantError(
-                        "Address not supported at device at ID {self._wr_unit}."
+                        f"Address not supported at device at ID {self._wr_unit}."
                     )
 
                 if result.exception_code == ModbusExceptions.IllegalFunction:
@@ -716,13 +716,13 @@ class SolarEdgeModbusMultiHub:
                         f"Unit {self._wr_unit} Write IllegalFunction: {result}"
                     )
                     raise HomeAssistantError(
-                        "Function not supported by device at ID {self._wr_unit}."
+                        f"Function not supported by device at ID {self._wr_unit}."
                     )
 
                 if result.exception_code == ModbusExceptions.IllegalValue:
                     _LOGGER.debug(f"Unit {self._wr_unit} Write IllegalValue: {result}")
                     raise HomeAssistantError(
-                        "Value invalid for device at ID {self._wr_unit}."
+                        f"Value invalid for device at ID {self._wr_unit}."
                     )
 
             await self.disconnect()


### PR DESCRIPTION
## Proposed change

Four error messages in the write path are missing their `f` prefix, so the placeholder is
logged literally:

```
No response from inverter ID {self._wr_unit}.
```

instead of the actual device ID. The messages are the ones a user sees when a write
fails, so they are exactly the ones that need to name the device.

No logic change, only the four strings.

## Testing

Not triggered on my system - my writes are intentionally disabled, so I have not produced
one of these errors on real hardware. The change is a literal string fix that is visible
by reading it: without the prefix Python emits the braces verbatim.

I would rather say that plainly than claim a test I did not run.

## Checklist

- [x] Based on the latest upstream main.
- [x] One subject only.
- [ ] Tested against real hardware - see above, string-only change.