### PR TITLE
Fix the accumulator helper being called with the wrong arity

### DIFF
--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1788,8 +1788,8 @@ class MeterVAhIE(SolarEdgeSensorBase):
                 )
 
                 try:
-                    return update_accum(self, value, value)
-                except Exception:
+                    return update_accum(self, value)
+                except ValueError:
                     return None
 
         except TypeError:
@@ -1866,8 +1866,8 @@ class MetervarhIE(SolarEdgeSensorBase):
                 )
 
                 try:
-                    return update_accum(self, value, value)
-                except Exception:
+                    return update_accum(self, value)
+                except ValueError:
                     return None
 
         except TypeError:


### PR DESCRIPTION
## Problem

`update_accum()` is defined as `update_accum(self, accum_value)` in `helpers.py`, but both meter accumulator sensors call it with three arguments:

```python
return update_accum(self, value, value)
```

Every call raises `TypeError: update_accum() takes 2 positional arguments but 3 were given`. The call sits inside a bare `except Exception: return None`, so the error is swallowed and the affected entities simply report `None` forever. That is also why this went unnoticed: nothing appears in the log.

## Changes

- Pass the value once.
- Narrow the handler to `ValueError`, which is what `update_accum` legitimately raises for a non-increasing accumulator. A programming error is no longer hidden.

## Testing

Verified by reading the signature against the call sites - the mismatch is unconditional and does not depend on hardware.

**On my own system the affected entities stay unavailable even after this fix**, because my meter does not implement the corresponding scale factors: `M_VAh_SF` and `M_varh_SF` both return the not-implemented sentinel, and the existing scale-factor range check correctly keeps the entities unavailable. So I can confirm the crash is gone, but I cannot confirm a value on real hardware - that needs a meter that implements those registers.

## Checklist

- [x] Based on the latest upstream main.
- [x] One subject only.
- [x] Verified against the code; hardware limitation stated above.
