### PR TITLE
Make the accumulator saturation check reachable

### DIFF
--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -945,7 +945,8 @@ class SolarEdgeACEnergy(SolarEdgeSensorBase):
         try:
             if (
                 self._platform.decoded_model[self._model_key] == SunSpecAccum.NA32
-                or self._platform.decoded_model[self._model_key] > SunSpecAccum.LIMIT32
+                or self._platform.decoded_model[self._model_key]
+                >= SunSpecAccum.LIMIT32
                 or self._platform.decoded_model["AC_Energy_WH_SF"]
                 not in SUNSPEC_SF_RANGE
             ):
@@ -1775,7 +1776,7 @@ class MeterVAhIE(SolarEdgeSensorBase):
         try:
             if (
                 self._platform.decoded_model[model_key] == SunSpecAccum.NA32
-                or self._platform.decoded_model[model_key] > SunSpecAccum.LIMIT32
+                or self._platform.decoded_model[model_key] >= SunSpecAccum.LIMIT32
                 or self._platform.decoded_model["M_VAh_SF"] == SunSpecNotImpl.INT16
                 or self._platform.decoded_model["M_VAh_SF"] not in SUNSPEC_SF_RANGE
             ):
@@ -1853,7 +1854,7 @@ class MetervarhIE(SolarEdgeSensorBase):
         try:
             if (
                 self._platform.decoded_model[model_key] == SunSpecAccum.NA32
-                or self._platform.decoded_model[model_key] > SunSpecAccum.LIMIT32
+                or self._platform.decoded_model[model_key] >= SunSpecAccum.LIMIT32
                 or self._platform.decoded_model["M_varh_SF"] == SunSpecNotImpl.INT16
                 or self._platform.decoded_model["M_varh_SF"] not in SUNSPEC_SF_RANGE
             ):


### PR DESCRIPTION
## Problem

Three accumulator sensors treat a saturated SunSpec accumulator as unavailable:

```python
or self._platform.decoded_model[key] > SunSpecAccum.LIMIT32
```

`SunSpecAccum.LIMIT32` is `0xFFFFFFFF` and the value is decoded as UINT32, so it can never be greater than the limit. The check never fires, and a fully saturated accumulator is reported as a normal value.

## Changes

Compare with `>=` in `SolarEdgeACEnergy`, `MeterVAhIE` and `MetervarhIE`.

## Testing

Verified by reasoning about the value range, not on hardware: my accumulators are nowhere near saturation, so I cannot produce the condition on a real device. The change is a one-character comparison fix whose current form is unreachable by construction.

## Checklist

- [x] Based on the latest upstream main.
- [x] One subject only.
- [ ] Tested against real hardware - the condition cannot be produced on my system, see above.
