### PR TITLE
Drop device_class ENERGY from the VAh and varh meter sensors

### DIFF
--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1723,7 +1723,7 @@ class SolarEdgeMMPPTEvents(SolarEdgeSensorBase):
 
 
 class MeterVAhIE(SolarEdgeSensorBase):
-    device_class = SensorDeviceClass.ENERGY
+    # No device_class: ENERGY only allows Wh-based units, not VAh.
     state_class = SensorStateClass.TOTAL_INCREASING
     native_unit_of_measurement = ENERGY_VOLT_AMPERE_HOUR
 
@@ -1801,7 +1801,7 @@ class MeterVAhIE(SolarEdgeSensorBase):
 
 
 class MetervarhIE(SolarEdgeSensorBase):
-    device_class = SensorDeviceClass.ENERGY
+    # No device_class: ENERGY only allows Wh-based units, not varh.
     state_class = SensorStateClass.TOTAL_INCREASING
     native_unit_of_measurement = ENERGY_VOLT_AMPERE_REACTIVE_HOUR
 


### PR DESCRIPTION
## Problem

`MeterVAhIE` and `MetervarhIE` declare `device_class = SensorDeviceClass.ENERGY` while using the units `VAh` and `varh`. Home Assistant validates the unit against the device class and only accepts Wh-based units for `ENERGY`, so it logs

```
<entity> is using native unit of measurement 'VAh' which is not a valid unit for the device class ('energy')
```

and long term statistics are not compiled for those entities.

## Changes

Remove the device class from those two sensors and keep `state_class = TOTAL_INCREASING`, so statistics still work with the custom units. The other energy sensors, which report Wh, are untouched.

## Testing

Verified against Home Assistant's unit validation for the energy device class. The affected entities are disabled by default and unavailable on my meter (it does not implement the VAh/varh scale factors), so I have not seen the warning on my own system - it follows from the declared unit.

## Checklist

- [x] Based on the latest upstream main.
- [x] One subject only.
- [ ] Tested against real hardware - entities unavailable on my meter, see above.
