### PR TITLE
Use reactive energy units/classes from HA core

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Inverter site limit and battery storage controls are disabled by default: not al
 
 ### Minimum Required Versions
 
-- Home Assistant 2025.2.0 (HA=>2025.9.0 requires release v3.1.7 or newer)
+- Home Assistant 2025.6.0 (HA=>2025.9.0 requires release v3.1.7 or newer)
 - pymodbus 3.8.3 (pymodbus>=3.10.0 requires release v3.1.6 or newer)
 
 ## Specifications

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -19,7 +19,6 @@ PYMODBUS_REQUIRED_VERSION = "3.8.3"
 
 # units missing in homeassistant core
 ENERGY_VOLT_AMPERE_HOUR: Final = "VAh"
-ENERGY_VOLT_AMPERE_REACTIVE_HOUR: Final = "varh"
 
 # from voluptuous/validators.py
 DOMAIN_REGEX = re.compile(

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfFrequency,
     UnitOfPower,
+    UnitOfReactiveEnergy,
     UnitOfReactivePower,
     UnitOfTemperature,
 )
@@ -35,7 +36,6 @@ from .const import (
     DEVICE_STATUS_TEXT,
     DOMAIN,
     ENERGY_VOLT_AMPERE_HOUR,
-    ENERGY_VOLT_AMPERE_REACTIVE_HOUR,
     INVERTED_POWER_VERSION,
     METER_EVENTS,
     MMPPT_EVENTS,
@@ -1801,9 +1801,9 @@ class MeterVAhIE(SolarEdgeSensorBase):
 
 
 class MetervarhIE(SolarEdgeSensorBase):
-    device_class = SensorDeviceClass.ENERGY
+    device_class = SensorDeviceClass.REACTIVE_ENERGY
     state_class = SensorStateClass.TOTAL_INCREASING
-    native_unit_of_measurement = ENERGY_VOLT_AMPERE_REACTIVE_HOUR
+    native_unit_of_measurement = UnitOfReactiveEnergy.VOLT_AMPERE_REACTIVE_HOUR
 
     def __init__(self, platform, config_entry, coordinator, phase: str = None):
         super().__init__(platform, config_entry, coordinator)

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "SolarEdge Modbus Multi",
   "content_in_root": false,
-  "homeassistant": "2025.2.0"
+  "homeassistant": "2025.6.0"
 }


### PR DESCRIPTION
Many years ago we created our own ENERGY_VOLT_AMPERE_REACTIVE_HOUR constant before HA supported it in core. Now that UnitOfReactiveEnergy is available from HA core (along with a SensorDeviceClass and ) we can use those.