### PR TITLE
Manual setup bypass Device ID check

### DIFF
--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import (
+    BYPASS_DEVICE_CHECK,
     DEFAULT_NAME,
     DOMAIN,
     SETUP_MANUAL,
@@ -267,6 +268,33 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors[CONF_HOST] = "invalid_host"
             elif not 1 <= user_input[CONF_PORT] <= 65535:
                 errors[CONF_PORT] = "invalid_tcp_port"
+            elif user_input[BYPASS_DEVICE_CHECK]:
+                try:
+                    device_list = device_list_from_string(
+                        user_input[ConfName.DEVICE_LIST]
+                    )
+                except HomeAssistantError as e:
+                    errors[ConfName.DEVICE_LIST] = f"{e}"
+                else:
+                    if not 1 <= len(device_list) <= 32:
+                        errors[ConfName.DEVICE_LIST] = "invalid_inverter_count"
+                    else:
+                        user_input[ConfName.DEVICE_LIST] = device_list
+
+                        new_unique_id = (
+                            f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}"
+                        )
+                        await self.async_set_unique_id(new_unique_id)
+
+                        self._abort_if_unique_id_configured()
+
+                        del user_input[BYPASS_DEVICE_CHECK]
+                        self._pending_entry = {
+                            "title": user_input[CONF_NAME],
+                            "data": user_input,
+                        }
+
+                        return await self.async_step_features_info()
             else:
                 scanner = SolarEdgeDeviceScanner(
                     host=user_input[CONF_HOST],
@@ -319,6 +347,7 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                         self._abort_if_unique_id_configured()
 
+                        del user_input[BYPASS_DEVICE_CHECK]
                         self._pending_entry = {
                             "title": user_input[CONF_NAME],
                             "data": user_input,
@@ -336,6 +365,7 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_HOST: "",
                 CONF_PORT: ConfDefaultInt.PORT,
                 ConfName.DEVICE_LIST: ConfDefaultStr.DEVICE_LIST,
+                BYPASS_DEVICE_CHECK: False,
             }
 
         return self.async_show_form(
@@ -351,6 +381,10 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         f"{ConfName.DEVICE_LIST}",
                         default=user_input[ConfName.DEVICE_LIST],
                     ): cv.string,
+                    vol.Optional(
+                        BYPASS_DEVICE_CHECK,
+                        default=user_input.get(BYPASS_DEVICE_CHECK, False),
+                    ): cv.boolean,
                 },
             ),
             errors=errors,

--- a/custom_components/solaredge_modbus_multi/const.py
+++ b/custom_components/solaredge_modbus_multi/const.py
@@ -13,6 +13,7 @@ SETUP_TYPE = "setup_type"
 SETUP_SCAN_FAST = "scan_fast"  # Scan IDs 1-32
 SETUP_SCAN_FULL = "scan_full"  # Scan IDs 1-247
 SETUP_MANUAL = "manual_list"
+BYPASS_DEVICE_CHECK = "bypass_device_check"
 
 # raise a startup exception if pymodbus version is less than this
 PYMODBUS_REQUIRED_VERSION = "3.8.3"

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -20,7 +20,11 @@
           "name": "Sensor Prefix",
           "host": "Inverter IP Address",
           "port": "Modbus/TCP Port",
-          "device_list": "Inverter Device ID List"
+          "device_list": "Inverter Device ID List",
+          "bypass_device_check": "Skip Device ID validation"
+        },
+        "data_description": {
+          "bypass_device_check": "Add the Device ID list without connecting to check that each ID responds as a SolarEdge inverter. Use this only if the check fails for a device you know is correct, such as one that is offline during setup."
         }
       },
       "scan_ask_host": {

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -20,7 +20,11 @@
           "name": "Sensorpräfix",
           "host": "Wechselrichter-IP-Adresse",
           "port": "Modbus/TCP-Port",
-          "device_list": "Liste der Wechselrichter-Geräte-IDs"
+          "device_list": "Liste der Wechselrichter-Geräte-IDs",
+          "bypass_device_check": "Geräte-ID-Prüfung überspringen"
+        },
+        "data_description": {
+          "bypass_device_check": "Fügen Sie die Geräte-ID-Liste hinzu, ohne zu prüfen, ob jede ID als SolarEdge-Wechselrichter antwortet. Verwenden Sie dies nur, wenn die Prüfung für ein Gerät fehlschlägt, von dem Sie wissen, dass es korrekt ist, z. B. eines, das während der Einrichtung offline ist."
         }
       },
       "scan_ask_host": {

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -20,7 +20,11 @@
           "name": "Sensor Prefix",
           "host": "Inverter IP Address",
           "port": "Modbus/TCP Port",
-          "device_list": "Inverter Device ID List"
+          "device_list": "Inverter Device ID List",
+          "bypass_device_check": "Skip Device ID validation"
+        },
+        "data_description": {
+          "bypass_device_check": "Add the Device ID list without connecting to check that each ID responds as a SolarEdge inverter. Use this only if the check fails for a device you know is correct, such as one that is offline during setup."
         }
       },
       "scan_ask_host": {

--- a/custom_components/solaredge_modbus_multi/translations/fr.json
+++ b/custom_components/solaredge_modbus_multi/translations/fr.json
@@ -20,7 +20,11 @@
           "name": "Prefix du capteur",
           "host": "Adresse IP de l'onduleur",
           "port": "Port Modbus/TCP",
-          "device_list": "Liste des ID des appareils de l'onduleur"
+          "device_list": "Liste des ID des appareils de l'onduleur",
+          "bypass_device_check": "Ignorer la validation des ID d'appareil"
+        },
+        "data_description": {
+          "bypass_device_check": "Ajoutez la liste des ID d'appareil sans vérifier que chaque ID répond en tant qu'onduleur SolarEdge. Utilisez cette option uniquement si la vérification échoue pour un appareil que vous savez correct, comme un appareil hors ligne pendant la configuration."
         }
       },
       "scan_ask_host": {

--- a/custom_components/solaredge_modbus_multi/translations/fr.json
+++ b/custom_components/solaredge_modbus_multi/translations/fr.json
@@ -57,7 +57,7 @@
       "invalid_inverter_count": "Doit être entre 1 et 32 onduleurs.",
       "invalid_host": "Adresse IP invalide.",
       "invalid_tcp_port": "La plage de ports valide est comprise entre 1 et 65535.",
-      "invalid_range_format": "L'entrée ressemble à une plage mais un seul « - » par plage est autorisé.",
+      "invalid_range_format": "L'entrée ressemble à une plage mais un seul « - » par plage est autorisé.",
       "invalid_range_lte": "L’ID de début d’une plage doit être inférieur ou égal à l’ID de fin.",
       "empty_device_id": "La liste d'ID contient une valeur vide ou non définie.",
       "scan_failed": "Échec du scan des onduleurs. Veuillez vérifier votre connexion et réessayer."
@@ -128,7 +128,7 @@
           "invalid_inverter_count": "Doit être entre 1 et 32 onduleurs.",
           "invalid_host": "Adresse IP invalide.",
           "invalid_tcp_port": "La plage de ports valide est comprise entre 1 et 65535.",
-          "invalid_range_format": "L'entrée ressemble à une plage mais un seul « - » par plage est autorisé.",
+          "invalid_range_format": "L'entrée ressemble à une plage mais un seul « - » par plage est autorisé.",
           "invalid_range_lte": "L’ID de début d’une plage doit être inférieur ou égal à l’ID de fin.",
           "empty_device_id": "La liste d'ID contient une valeur vide ou non définie.",
           "already_configured": "L'hôte et le port sont déjà configurés dans un autre hub."

--- a/custom_components/solaredge_modbus_multi/translations/it.json
+++ b/custom_components/solaredge_modbus_multi/translations/it.json
@@ -20,7 +20,11 @@
           "name": "Prefisso sensore",
           "host": "Indirizzo IP dell'inverter",
           "port": "Porta Modbus/TCP",
-          "device_list": "Elenco ID dispositivi inverter"
+          "device_list": "Elenco ID dispositivi inverter",
+          "bypass_device_check": "Salta la convalida dell'ID dispositivo"
+        },
+        "data_description": {
+          "bypass_device_check": "Aggiungi l'elenco degli ID dispositivo senza verificare che ciascun ID risponda come inverter SolarEdge. Usa questa opzione solo se il controllo fallisce per un dispositivo che sai essere corretto, ad esempio uno offline durante la configurazione."
         }
       },
       "scan_ask_host": {

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -20,7 +20,11 @@
           "name": "Sensorvoorvoegsel",
           "host": "IP-adres van omvormer",
           "port": "Modbus/TCP-poort",
-          "device_list": "Inverter-enhetsliste"
+          "device_list": "Inverter-enhetsliste",
+          "bypass_device_check": "Hopp over validering av enhets-ID"
+        },
+        "data_description": {
+          "bypass_device_check": "Legg til enhets-ID-listen uten å koble til for å sjekke at hver ID svarer som en SolarEdge-vekselretter. Bruk dette bare hvis kontrollen mislykkes for en enhet du vet er riktig, for eksempel en som er frakoblet under oppsettet."
         }
       },
       "scan_ask_host": {

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -20,7 +20,11 @@
           "name": "Sensor prefix",
           "host": "omvormer IP-adres",
           "port": "Modbus/TCP Port",
-          "device_list": "Omvormerapparaat-ID-lijst"
+          "device_list": "Omvormerapparaat-ID-lijst",
+          "bypass_device_check": "ID-controle overslaan"
+        },
+        "data_description": {
+          "bypass_device_check": "Voeg de apparaat-ID-lijst toe zonder verbinding te maken om te controleren of elke ID reageert als een SolarEdge-omvormer. Gebruik dit alleen als de controle mislukt voor een apparaat waarvan u weet dat het correct is, bijvoorbeeld een apparaat dat offline is tijdens de installatie."
         }
       },
       "scan_ask_host": {

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -20,7 +20,11 @@
           "name": "Prefix sensora",
           "host": "Adres IP inwertera",
           "port": "Modbus/TCP Port",
-          "device_list": "Lista identyfikatorów urządzeń falownika"
+          "device_list": "Lista identyfikatorów urządzeń falownika",
+          "bypass_device_check": "Pomiń weryfikację ID urządzenia"
+        },
+        "data_description": {
+          "bypass_device_check": "Dodaj listę identyfikatorów urządzeń bez łączenia się w celu sprawdzenia, czy każdy identyfikator odpowiada jako falownik SolarEdge. Użyj tej opcji tylko wtedy, gdy weryfikacja nie powiedzie się dla urządzenia, o którym wiesz, że jest poprawne, np. takiego, które jest offline podczas konfiguracji."
         }
       },
       "scan_ask_host": {


### PR DESCRIPTION
Add a config flow option in manual setup mode to bypass checking if the Device ID(s) have a SolarEdge inverter signature.