### PR TITLE
Fix incorrect use of 'or' comparison for ipaddress

### DIFF
--- a/custom_components/solaredge_modbus_multi/helpers.py
+++ b/custom_components/solaredge_modbus_multi/helpers.py
@@ -51,9 +51,7 @@ def update_accum(self, accum_value: int) -> None:
 def host_valid(host):
     """Return True if hostname or IP address is valid."""
     try:
-        if ipaddress.ip_address(host).version == (4 or 6):
-            return True
-
+        return ipaddress.ip_address(host).version in (4, 6)
     except ValueError:
         return DOMAIN_REGEX.match(host)
 


### PR DESCRIPTION
Fix incorrect use of 'or' comparison for ipaddress. It would only have been noticed for an IPv6 addressed modbus/tcp host, which SolarEdge inverters don't support anyway, but someone might have a v6 proxy.