### PR TITLE
Add Autodiscovery

### DIFF
--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import (
     BYPASS_DEVICE_CHECK,
@@ -86,6 +87,7 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._scan_user_input = None
         self._scan_task_result = None
         self._pending_entry = None
+        self._discovered = None
 
     @staticmethod
     @callback
@@ -142,6 +144,47 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_menu(
             step_id="user",
             menu_options=[SETUP_SCAN_FAST, SETUP_SCAN_FULL, SETUP_MANUAL],
+        )
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle a SolarEdge Modbus/TCP gateway discovered via mDNS."""
+        host = discovery_info.host.lower()
+        port = discovery_info.port
+
+        await self.async_set_unique_id(f"{host}:{port}")
+        self._abort_if_unique_id_configured(updates={CONF_HOST: host, CONF_PORT: port})
+
+        self._discovered = {CONF_HOST: host, CONF_PORT: port}
+        self.context["title_placeholders"] = {"host": host}
+
+        return await self.async_step_zeroconf_confirm()
+
+    async def async_step_zeroconf_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm setup of a discovered SolarEdge Modbus/TCP gateway."""
+        if user_input is not None:
+            self.init_info = {SETUP_TYPE: SETUP_SCAN_FAST}
+
+            return await self.async_step_scan_ask_host(
+                {
+                    CONF_NAME: user_input[CONF_NAME],
+                    CONF_HOST: self._discovered[CONF_HOST],
+                    CONF_PORT: self._discovered[CONF_PORT],
+                }
+            )
+
+        return self.async_show_form(
+            step_id="zeroconf_confirm",
+            data_schema=vol.Schema(
+                {vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string}
+            ),
+            description_placeholders={
+                CONF_HOST: self._discovered[CONF_HOST],
+                CONF_PORT: str(self._discovered[CONF_PORT]),
+            },
         )
 
     async def async_step_scan_fast(

--- a/custom_components/solaredge_modbus_multi/manifest.json
+++ b/custom_components/solaredge_modbus_multi/manifest.json
@@ -10,5 +10,6 @@
   "issue_tracker": "https://github.com/WillCodeForCats/solaredge-modbus-multi/issues",
   "loggers": ["custom_components.solaredge_modbus_multi"],
   "requirements": ["pymodbus>=3.8.3", "awesomeversion>=25.5.0"],
-  "version": "3.3.6"
+  "version": "3.3.6",
+  "zeroconf": ["_solaredge-modbus._tcp.local."]
 }

--- a/custom_components/solaredge_modbus_multi/strings.json
+++ b/custom_components/solaredge_modbus_multi/strings.json
@@ -14,6 +14,13 @@
           "manual_list": "Manually enter a list of inverter Device IDs"
         }
       },
+      "zeroconf_confirm": {
+        "title": "Discovered SolarEdge Inverter",
+        "description": "A SolarEdge Modbus/TCP gateway was found at {host}:{port}. Set it up now?",
+        "data": {
+          "name": "Sensor Prefix"
+        }
+      },
       "manual": {
         "title": "Manual Modbus Configuration",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/de.json
+++ b/custom_components/solaredge_modbus_multi/translations/de.json
@@ -14,6 +14,13 @@
           "manual_list": "Manuelle Eingabe einer Liste von Wechselrichter-Geräte-IDs"
         }
       },
+      "zeroconf_confirm": {
+        "title": "Entdeckter SolarEdge-Wechselrichter",
+        "description": "Ein SolarEdge Modbus/TCP-Gateway wurde unter {host}:{port} gefunden. Jetzt einrichten?",
+        "data": {
+          "name": "Sensorpräfix"
+        }
+      },
       "manual": {
         "title": "Manuelle Modbus-Konfiguration",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/en.json
+++ b/custom_components/solaredge_modbus_multi/translations/en.json
@@ -14,6 +14,13 @@
           "manual_list": "Manually enter a list of inverter Device IDs"
         }
       },
+      "zeroconf_confirm": {
+        "title": "Discovered SolarEdge Inverter",
+        "description": "A SolarEdge Modbus/TCP gateway was found at {host}:{port}. Set it up now?",
+        "data": {
+          "name": "Sensor Prefix"
+        }
+      },
       "manual": {
         "title": "Manual Modbus Configuration",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/fr.json
+++ b/custom_components/solaredge_modbus_multi/translations/fr.json
@@ -14,6 +14,13 @@
           "manual_list": "Entrer manuellement une liste d'ID d'appareils onduleurs"
         }
       },
+      "zeroconf_confirm": {
+        "title": "Onduleur SolarEdge détecté",
+        "description": "Une passerelle SolarEdge Modbus/TCP a été trouvée à {host}:{port}. La configurer maintenant ?",
+        "data": {
+          "name": "Prefix du capteur"
+        }
+      },
       "manual": {
         "title": "Configuration Modbus manuelle",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/it.json
+++ b/custom_components/solaredge_modbus_multi/translations/it.json
@@ -14,6 +14,13 @@
           "manual_list": "Inserisci manualmente un elenco di ID dispositivo inverter"
         }
       },
+      "zeroconf_confirm": {
+        "title": "Inverter SolarEdge rilevato",
+        "description": "È stato trovato un gateway SolarEdge Modbus/TCP a {host}:{port}. Configurarlo ora?",
+        "data": {
+          "name": "Prefisso sensore"
+        }
+      },
       "manual": {
         "title": "Configurazione Modbus manuale",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/nb.json
+++ b/custom_components/solaredge_modbus_multi/translations/nb.json
@@ -14,6 +14,13 @@
           "manual_list": "Skriv inn en liste over vekselretter-enhets-IDer manuelt"
         }
       },
+      "zeroconf_confirm": {
+        "title": "Oppdaget SolarEdge-vekselretter",
+        "description": "En SolarEdge Modbus/TCP-gateway ble funnet på {host}:{port}. Sette den opp nå?",
+        "data": {
+          "name": "Sensorprefiks"
+        }
+      },
       "manual": {
         "title": "Manuell Modbus-konfigurasjon",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/nl.json
+++ b/custom_components/solaredge_modbus_multi/translations/nl.json
@@ -14,6 +14,13 @@
           "manual_list": "Voer handmatig een lijst van omvormer-apparaat-ID's in"
         }
       },
+      "zeroconf_confirm": {
+        "title": "Ontdekte SolarEdge-omvormer",
+        "description": "Er is een SolarEdge Modbus/TCP-gateway gevonden op {host}:{port}. Nu instellen?",
+        "data": {
+          "name": "Sensor prefix"
+        }
+      },
       "manual": {
         "title": "Handmatige Modbus-configuratie",
         "data": {

--- a/custom_components/solaredge_modbus_multi/translations/pl.json
+++ b/custom_components/solaredge_modbus_multi/translations/pl.json
@@ -14,6 +14,13 @@
           "manual_list": "Ręcznie wprowadź listę identyfikatorów urządzeń inwertera"
         }
       },
+      "zeroconf_confirm": {
+        "title": "Wykryto falownik SolarEdge",
+        "description": "Znaleziono bramę SolarEdge Modbus/TCP pod adresem {host}:{port}. Skonfigurować teraz?",
+        "data": {
+          "name": "Prefix sensora"
+        }
+      },
       "manual": {
         "title": "Ręczna konfiguracja Modbus",
         "data": {

--- a/tests/test_config_flow_zeroconf.py
+++ b/tests/test_config_flow_zeroconf.py
@@ -1,0 +1,59 @@
+"""Tests for zeroconf/mDNS discovery in config_flow.py."""
+
+from ipaddress import ip_address
+
+import pytest
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.solaredge_modbus_multi.const import DOMAIN
+
+DISCOVERY_INFO = ZeroconfServiceInfo(
+    ip_address=ip_address("192.168.1.50"),
+    ip_addresses=[ip_address("192.168.1.50")],
+    port=1502,
+    hostname="solaredge-gateway.local.",
+    type="_solaredge-modbus._tcp.local.",
+    name="SolarEdge Gateway._solaredge-modbus._tcp.local.",
+    properties={},
+)
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_zeroconf_discovery_shows_confirm_form(hass):
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "zeroconf_confirm"
+    assert result["description_placeholders"] == {
+        CONF_HOST: "192.168.1.50",
+        CONF_PORT: "1502",
+    }
+
+    flow = hass.config_entries.flow.async_get(result["flow_id"])
+    assert flow["context"]["unique_id"] == "192.168.1.50:1502"
+    assert flow["context"]["title_placeholders"] == {"host": "192.168.1.50"}
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_zeroconf_discovery_aborts_if_already_configured(hass):
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.1.50:1502",
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 1502},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"


### PR DESCRIPTION
Add Autodiscovery to integration. Zeroconf only publishes one modbus address (presumably the leader's address) so we still need to step into fast scan (IDs 1-32) on the autoconfig path to complete setup for multiple inverters.