### PR TITLE
Add a write counter sensor entity

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -905,6 +905,7 @@ class SolarEdgeInverter:
         self.site_limit_control = None
         self._grid_status = None
         self._use_status_vendor4 = False
+        self.write_count = 0
 
     async def init_device(self) -> None:
         """Set up data about the device from modbus."""
@@ -1970,6 +1971,7 @@ class SolarEdgeInverter:
         """Write inverter register."""
         await self.hub.write_registers(self.inverter_unit_id, address, payload)
 
+        self.write_count += 1
     @property
     def online(self) -> bool:
         """Device is online."""

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -906,6 +906,7 @@ class SolarEdgeInverter:
         self._grid_status = None
         self._use_status_vendor4 = False
         self.write_count = 0
+        self.write_count_listeners = set()
 
     async def init_device(self) -> None:
         """Set up data about the device from modbus."""
@@ -1972,6 +1973,9 @@ class SolarEdgeInverter:
         await self.hub.write_registers(self.inverter_unit_id, address, payload)
 
         self.write_count += 1
+        for listener in list(self.write_count_listeners):
+            listener()
+
     @property
     def online(self) -> bool:
         """Device is online."""

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -27,6 +27,7 @@ from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1333,7 +1333,7 @@ class SolarEdgeWriteCount(RestoreEntity, SolarEdgeSensorBase):
 
     Tracks writes for possible flash wear. This counts only writes we
     addressed to this specific unit ID. A leader inverter may propagate
-    settings to linked followers internally, but the intergation can't know that,
+    settings to linked followers internally, but the integration can't know that,
     so it isn't reflected in any other unit's write count. See discussion
     https://github.com/WillCodeForCats/solaredge-modbus-multi/discussions/727
     """

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -13,6 +13,8 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     UnitOfApparentPower,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -92,6 +94,7 @@ async def async_setup_entry(
         entities.append(DCVoltage(inverter, config_entry, coordinator))
         entities.append(DCPower(inverter, config_entry, coordinator))
         entities.append(HeatSinkTemperature(inverter, config_entry, coordinator))
+        entities.append(SolarEdgeWriteCount(inverter, config_entry, coordinator))
 
         if hub.option_detect_extras and inverter.global_power_control:
             entities.append(SolarEdgeRRCR(inverter, config_entry, coordinator))
@@ -1323,6 +1326,57 @@ class SolarEdgeTemperatureMMPPT(SolarEdgeSensorBase):
     @property
     def native_value(self):
         return self._platform.inverter.decoded_model[self._platform.mmppt_key]["Tmp"]
+
+
+class SolarEdgeWriteCount(RestoreEntity, SolarEdgeSensorBase):
+    """Number of Modbus write commands sent to the inverter.
+
+    Tracks writes for possible flash wear. See discussion
+    https://github.com/WillCodeForCats/solaredge-modbus-multi/discussions/727
+    """
+
+    entity_category = EntityCategory.DIAGNOSTIC
+    state_class = SensorStateClass.TOTAL_INCREASING
+    icon = "mdi:file-document-edit-outline"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._platform.uid_base}_write_count"
+
+    @property
+    def name(self) -> str:
+        return "Write Count"
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def native_value(self):
+        return self._platform.write_count
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+
+        last_state = await self.async_get_last_state()
+        if last_state is not None and last_state.state not in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+        ):
+            try:
+                self._platform.write_count = int(last_state.state)
+            except ValueError:
+                pass
+
+        self._platform.write_count_listeners.add(self._write_count_updated)
+
+    async def async_will_remove_from_hass(self) -> None:
+        self._platform.write_count_listeners.discard(self._write_count_updated)
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _write_count_updated(self) -> None:
+        self.async_write_ha_state()
 
 
 class SolarEdgeStatusSensor(SolarEdgeSensorBase):

--- a/custom_components/solaredge_modbus_multi/sensor.py
+++ b/custom_components/solaredge_modbus_multi/sensor.py
@@ -1329,9 +1329,12 @@ class SolarEdgeTemperatureMMPPT(SolarEdgeSensorBase):
 
 
 class SolarEdgeWriteCount(RestoreEntity, SolarEdgeSensorBase):
-    """Number of Modbus write commands sent to the inverter.
+    """Number of Modbus write commands sent to this inverter's unit ID.
 
-    Tracks writes for possible flash wear. See discussion
+    Tracks writes for possible flash wear. This counts only writes we
+    addressed to this specific unit ID. A leader inverter may propagate
+    settings to linked followers internally, but the intergation can't know that,
+    so it isn't reflected in any other unit's write count. See discussion
     https://github.com/WillCodeForCats/solaredge-modbus-multi/discussions/727
     """
 

--- a/tests/test_sensor_write_count.py
+++ b/tests/test_sensor_write_count.py
@@ -1,0 +1,109 @@
+"""Tests for SolarEdgeWriteCount in sensor.py.
+
+Added in 1c201ff "Add sensor SolarEdgeWriteCount" to track modbus write commands
+for flash-wear visibility (see discussion #727).
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import State
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from pytest_homeassistant_custom_component.common import mock_restore_cache
+
+from custom_components.solaredge_modbus_multi.sensor import SolarEdgeWriteCount
+
+
+def _make_platform(write_count=0):
+    return SimpleNamespace(
+        uid_base="inverter_1",
+        write_count=write_count,
+        write_count_listeners=set(),
+    )
+
+
+def _make_entity(hass, platform):
+    coordinator = DataUpdateCoordinator(
+        hass, logging.getLogger(__name__), config_entry=None, name="test"
+    )
+    entity = SolarEdgeWriteCount(platform, None, coordinator)
+    entity.hass = hass
+    entity.entity_id = "sensor.inverter_1_write_count"
+    return entity
+
+
+def test_unique_id():
+    entity = SolarEdgeWriteCount(_make_platform(), None, None)
+    assert entity.unique_id == "inverter_1_write_count"
+
+
+def test_name():
+    entity = SolarEdgeWriteCount(_make_platform(), None, None)
+    assert entity.name == "Write Count"
+
+
+def test_always_available():
+    entity = SolarEdgeWriteCount(_make_platform(), None, None)
+    assert entity.available is True
+
+
+def test_native_value_reads_from_platform():
+    entity = SolarEdgeWriteCount(_make_platform(write_count=7), None, None)
+    assert entity.native_value == 7
+
+
+def test_write_count_updated_writes_ha_state(monkeypatch):
+    entity = SolarEdgeWriteCount(_make_platform(), None, None)
+    calls = []
+    monkeypatch.setattr(entity, "async_write_ha_state", lambda: calls.append(True))
+
+    entity._write_count_updated()
+
+    assert calls == [True]
+
+
+async def test_restores_last_state_on_add(hass):
+    platform = _make_platform(write_count=0)
+    entity = _make_entity(hass, platform)
+    mock_restore_cache(hass, [State(entity.entity_id, "42")])
+
+    await entity.async_added_to_hass()
+
+    assert platform.write_count == 42
+    assert entity._write_count_updated in platform.write_count_listeners
+
+
+@pytest.mark.parametrize("last_state", [STATE_UNAVAILABLE, STATE_UNKNOWN])
+async def test_does_not_restore_unavailable_or_unknown(hass, last_state):
+    platform = _make_platform(write_count=3)
+    entity = _make_entity(hass, platform)
+    mock_restore_cache(hass, [State(entity.entity_id, last_state)])
+
+    await entity.async_added_to_hass()
+
+    assert platform.write_count == 3
+
+
+async def test_does_not_restore_non_numeric_state(hass):
+    # Checks the `except ValueError: pass` condition
+    platform = _make_platform(write_count=3)
+    entity = _make_entity(hass, platform)
+    mock_restore_cache(hass, [State(entity.entity_id, "not-a-number")])
+
+    await entity.async_added_to_hass()
+
+    assert platform.write_count == 3
+
+
+async def test_removes_listener_on_remove(hass):
+    platform = _make_platform()
+    entity = _make_entity(hass, platform)
+    mock_restore_cache(hass, [])
+    await entity.async_added_to_hass()
+    assert entity._write_count_updated in platform.write_count_listeners
+
+    await entity.async_will_remove_from_hass()
+
+    assert entity._write_count_updated not in platform.write_count_listeners


### PR DESCRIPTION
Add a write counter sensor entity. Tracks writes for possible flash wear. See discussion https://github.com/WillCodeForCats/solaredge-modbus-multi/discussions/727