### PR TITLE
Don't track Active Power Limit and CosPhi writes

### DIFF
--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -1968,9 +1968,16 @@ class SolarEdgeInverter:
                     f"No response from inverter ID {self.inverter_unit_id}"
                 )
 
-    async def write_registers(self, address, payload) -> None:
-        """Write inverter register."""
+    async def write_registers(self, address, payload, count_write: bool = True) -> None:
+        """Write inverter register.
+
+        count_write=False is for dynamic setpoints that don't count against
+        flash wear the write count sensor is meant to track.
+        """
         await self.hub.write_registers(self.inverter_unit_id, address, payload)
+
+        if not count_write:
+            return
 
         self.write_count += 1
         for listener in list(self.write_count_listeners):

--- a/custom_components/solaredge_modbus_multi/number.py
+++ b/custom_components/solaredge_modbus_multi/number.py
@@ -563,6 +563,7 @@ class SolarEdgeActivePowerLimitSet(SolarEdgeNumberBase):
                 data_type=ModbusClientMixin.DATATYPE.UINT16,
                 word_order="little",
             ),
+            count_write=False,
         )
         await self.async_update()
 
@@ -617,6 +618,7 @@ class SolarEdgeCosPhiSet(SolarEdgeNumberBase):
                 data_type=ModbusClientMixin.DATATYPE.FLOAT32,
                 word_order="little",
             ),
+            count_write=False,
         )
         await self.async_update()
 

--- a/tests/test_sensor_write_count.py
+++ b/tests/test_sensor_write_count.py
@@ -2,10 +2,15 @@
 
 Added in 1c201ff "Add sensor SolarEdgeWriteCount" to track modbus write commands
 for flash-wear visibility (see discussion #727).
+
+95b9d9e "Add a flag to not track a write" (Active Power Limit and CosPhi are
+dynamic setpoints that aren't saved to inverter flash, so they shouldn't count
+against the flash-wear counter).
 """
 
 import logging
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
@@ -13,6 +18,7 @@ from homeassistant.core import State
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from pytest_homeassistant_custom_component.common import mock_restore_cache
 
+from custom_components.solaredge_modbus_multi.hub import SolarEdgeInverter
 from custom_components.solaredge_modbus_multi.sensor import SolarEdgeWriteCount
 
 
@@ -22,6 +28,11 @@ def _make_platform(write_count=0):
         write_count=write_count,
         write_count_listeners=set(),
     )
+
+
+def _make_inverter():
+    stub_hub = SimpleNamespace(write_registers=AsyncMock())
+    return SolarEdgeInverter(1, stub_hub)
 
 
 def _make_entity(hass, platform):
@@ -107,3 +118,29 @@ async def test_removes_listener_on_remove(hass):
     await entity.async_will_remove_from_hass()
 
     assert entity._write_count_updated not in platform.write_count_listeners
+
+
+async def test_write_registers_counts_by_default():
+    inverter = _make_inverter()
+    calls = []
+    inverter.write_count_listeners.add(lambda: calls.append(True))
+
+    await inverter.write_registers(40001, [1])
+
+    inverter.hub.write_registers.assert_awaited_once_with(1, 40001, [1])
+    assert inverter.write_count == 1
+    assert calls == [True]
+
+
+async def test_write_registers_count_write_false_skips_counting():
+    # 95b9d9e "Add a flag to not track a write" - the write itself must still
+    # happen, only the counter/listener side is skipped.
+    inverter = _make_inverter()
+    calls = []
+    inverter.write_count_listeners.add(lambda: calls.append(True))
+
+    await inverter.write_registers(40001, [1], count_write=False)
+
+    inverter.hub.write_registers.assert_awaited_once_with(1, 40001, [1])
+    assert inverter.write_count == 0
+    assert calls == []


### PR DESCRIPTION
Active Power Limit and CosPhi are dynamic controls not saved in the inverter, so they shouldn't count against inverter flash write wear.