### PR TITLE
Replace via_device with via_device_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Inverter site limit and battery storage controls are disabled by default: not al
 
 ### Minimum Required Versions
 
-- Home Assistant 2025.6.0 (HA=>2025.9.0 requires release v3.1.7 or newer)
+- Home Assistant 2026.8.0 (HA=>2025.9.0 requires release v3.1.7 or newer)
 - pymodbus 3.8.3 (pymodbus>=3.10.0 requires release v3.1.6 or newer)
 
 ## Specifications

--- a/custom_components/solaredge_modbus_multi/hub.py
+++ b/custom_components/solaredge_modbus_multi/hub.py
@@ -13,6 +13,7 @@ from awesomeversion.exceptions import (
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity import DeviceInfo
 from pymodbus.client import AsyncModbusTcpClient
@@ -282,6 +283,14 @@ class SolarEdgeModbusMultiHub:
                 await new_inverter.init_device()
                 self.inverters.append(new_inverter)
 
+                # for via_device_id
+                device_registry = dr.async_get(self._hass)
+                inverter_device = device_registry.async_get_or_create(
+                    config_entry_id=self._entry_id,
+                    **new_inverter.device_info,
+                )
+                new_inverter.device_registry_id = inverter_device.id
+
                 ir.async_delete_issue(
                     self._hass,
                     DOMAIN,
@@ -341,7 +350,7 @@ class SolarEdgeModbusMultiHub:
                                     ),
                                 )
 
-                        new_meter.via_device = new_inverter.uid_base
+                        new_meter.via_device_id = new_inverter.device_registry_id
                         self.meters.append(new_meter)
                         _LOGGER.debug(f"Found I{inverter_unit_id}M{meter_id}")
 
@@ -377,7 +386,7 @@ class SolarEdgeModbusMultiHub:
                                     f"{new_battery.serial}"
                                 )
 
-                        new_battery.via_device = new_inverter.uid_base
+                        new_battery.via_device_id = new_inverter.device_registry_id
                         self.batteries.append(new_battery)
                         _LOGGER.debug(f"Found I{inverter_unit_id}B{battery_id}")
 
@@ -893,6 +902,7 @@ class SolarEdgeInverter:
     def __init__(self, device_id: int, hub: SolarEdgeModbusMultiHub) -> None:
         self.inverter_unit_id = device_id
         self.hub = hub
+        self.device_registry_id: str | None = None
         self.mmppt_units = []
         self.decoded_common = {}
         self.decoded_model = {}
@@ -2049,7 +2059,7 @@ class SolarEdgeMMPPTUnit:
             model=self.inverter.model,
             hw_version=f"ID {self.mmppt_id}",
             serial_number=f"{self.mmppt_idstr}",
-            via_device=(DOMAIN, self.inverter.uid_base),
+            via_device_id=self.inverter.device_registry_id,
         )
 
     @property
@@ -2075,7 +2085,7 @@ class SolarEdgeMeter:
         self.has_parent = True
         self.inverter_common = self.hub.inverter_common[self.inverter_unit_id]
         self.mmppt_common = self.hub.mmppt_common[self.inverter_unit_id]
-        self._via_device = None
+        self._via_device_id = None
 
         try:
             self.start_address = METER_REG_BASE[self.meter_id]
@@ -2390,16 +2400,16 @@ class SolarEdgeMeter:
             serial_number=self.serial,
             sw_version=self.fw_version,
             hw_version=self.option,
-            via_device=self.via_device,
+            via_device_id=self.via_device_id,
         )
 
     @property
-    def via_device(self) -> tuple[str, str]:
-        return self._via_device
+    def via_device_id(self) -> str | None:
+        return self._via_device_id
 
-    @via_device.setter
-    def via_device(self, device: str) -> None:
-        self._via_device = (DOMAIN, device)
+    @via_device_id.setter
+    def via_device_id(self, device_registry_id: str | None) -> None:
+        self._via_device_id = device_registry_id
 
 
 class SolarEdgeBattery:
@@ -2416,7 +2426,7 @@ class SolarEdgeBattery:
         self.battery_id = battery_id
         self.has_parent = True
         self.inverter_common = self.hub.inverter_common[self.inverter_unit_id]
-        self._via_device = None
+        self._via_device_id = None
 
         try:
             self.start_address = BATTERY_REG_BASE[self.battery_id]
@@ -2686,16 +2696,16 @@ class SolarEdgeBattery:
             model=self.model,
             serial_number=self.serial,
             sw_version=self.fw_version,
-            via_device=self.via_device,
+            via_device_id=self.via_device_id,
         )
 
     @property
-    def via_device(self) -> tuple[str, str]:
-        return self._via_device
+    def via_device_id(self) -> str | None:
+        return self._via_device_id
 
-    @via_device.setter
-    def via_device(self, device: str) -> None:
-        self._via_device = (DOMAIN, device)
+    @via_device_id.setter
+    def via_device_id(self, device_registry_id: str | None) -> None:
+        self._via_device_id = device_registry_id
 
     @property
     def allow_battery_energy_reset(self) -> bool:

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "SolarEdge Modbus Multi",
   "content_in_root": false,
-  "homeassistant": "2025.6.0"
+  "homeassistant": "2026.8.0"
 }


### PR DESCRIPTION
Replace via_device with via_device_id.

Required for HA 2027.8 but it starts generating a warning message in logs as of HA 2026.9.

Requires min HA core 2026.8.