### PR TITLE
Increase getaddrinfo lookup timeout to 5 seconds

### DIFF
--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -178,7 +178,7 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 addr_info = await asyncio.wait_for(
-                    self.hass.loop.getaddrinfo(existing_host, None), timeout=2.0
+                    self.hass.loop.getaddrinfo(existing_host, None), timeout=5.0
                 )
             except (OSError, asyncio.TimeoutError):
                 continue


### PR DESCRIPTION
Increase getaddrinfo lookup timeout to 5 seconds for discovery duplicate lookup.