### PR TITLE
Don't assume unique_id will always be the old host:port

### DIFF
--- a/custom_components/solaredge_modbus_multi/config_flow.py
+++ b/custom_components/solaredge_modbus_multi/config_flow.py
@@ -523,19 +523,34 @@ class SolaredgeModbusMultiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     user_input[ConfName.DEVICE_LIST] = device_list_from_string(
                         user_input[ConfName.DEVICE_LIST]
                     )
-                    this_unique_id = f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}"
 
-                    if this_unique_id != config_entry.unique_id:
-                        self._async_abort_entries_match(
-                            {
-                                "host": user_input[CONF_HOST],
-                                "port": user_input[CONF_PORT],
-                            }
+                    # unique_id may not be host:port forever. Only update
+                    # if it still looks like the host:port format.
+                    # Otherwise leave alone. A host/port change here is
+                    # a reconnect, not evidence the device itself changed.
+                    old_unique_id = (
+                        f"{config_entry.data.get(CONF_HOST)}:"
+                        f"{config_entry.data.get(CONF_PORT)}"
+                    )
+
+                    if config_entry.unique_id == old_unique_id:
+                        new_unique_id = (
+                            f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}"
                         )
+
+                        if new_unique_id != config_entry.unique_id:
+                            self._async_abort_entries_match(
+                                {
+                                    "host": user_input[CONF_HOST],
+                                    "port": user_input[CONF_PORT],
+                                }
+                            )
+                    else:
+                        new_unique_id = config_entry.unique_id
 
                     return self.async_update_reload_and_abort(
                         config_entry,
-                        unique_id=this_unique_id,
+                        unique_id=new_unique_id,
                         data={**config_entry.data, **user_input},
                         reason="reconfigure_successful",
                     )

--- a/tests/test_config_flow_reconfigure.py
+++ b/tests/test_config_flow_reconfigure.py
@@ -1,0 +1,152 @@
+"""Tests for the reconfigure flow's unique_id handling in config_flow.py."""
+
+import pytest
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_PORT
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.solaredge_modbus_multi.const import DOMAIN, ConfName
+
+
+async def _start_reconfigure(hass, entry):
+    return await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_reconfigure_updates_unique_id_when_still_host_port(hass):
+    """A unique_id still matches its own stored host:port
+    (the default scheme) gets it recomputed when the host changes."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.1.50:1502",
+        data={
+            CONF_HOST: "192.168.1.50",
+            CONF_PORT: 1502,
+            ConfName.DEVICE_LIST: [1],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_HOST: "192.168.1.60",
+            CONF_PORT: 1502,
+            ConfName.DEVICE_LIST: "1",
+        },
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.unique_id == "192.168.1.60:1502"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_reconfigure_preserves_non_host_port_unique_id(hass):
+    """A unique_id that no longer matches its stored host:port must not be
+    silently reset back to host:port by a routine host/port change."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="730663bc",
+        data={
+            CONF_HOST: "192.168.1.50",
+            CONF_PORT: 1502,
+            ConfName.DEVICE_LIST: [1],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_HOST: "192.168.1.60",
+            CONF_PORT: 1502,
+            ConfName.DEVICE_LIST: "1",
+        },
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.unique_id == "730663bc"
+    assert entry.data[CONF_HOST] == "192.168.1.60"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_reconfigure_aborts_on_host_port_collision(hass):
+    """Reconfiguring a host:port entry to another entry's existing
+    host:port must be rejected as a duplicate."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.1.99:1502",
+        data={
+            CONF_HOST: "192.168.1.99",
+            CONF_PORT: 1502,
+            ConfName.DEVICE_LIST: [1],
+        },
+    ).add_to_hass(hass)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.1.50:1502",
+        data={
+            CONF_HOST: "192.168.1.50",
+            CONF_PORT: 1502,
+            ConfName.DEVICE_LIST: [1],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_HOST: "192.168.1.99",
+            CONF_PORT: 1502,
+            ConfName.DEVICE_LIST: "1",
+        },
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_reconfigure_with_unchanged_host_port_succeeds(hass):
+    """Reconfiguring without changing host/port"""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="192.168.1.50:1502",
+        data={
+            CONF_HOST: "192.168.1.50",
+            CONF_PORT: 1502,
+            ConfName.DEVICE_LIST: [1],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_HOST: "192.168.1.50",
+            CONF_PORT: 1502,
+            ConfName.DEVICE_LIST: "1,2",
+        },
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.unique_id == "192.168.1.50:1502"
+    assert entry.data[ConfName.DEVICE_LIST] == [1, 2]


### PR DESCRIPTION
The `host:port` format for unique_id was chosen because 1) proxies hiding the actual inverter and 2) can't get a serial number without opening a connection. For 2) it seems that's acceptable for HA design, so we will probably migrate to that.

This PR makes sure reconfigure doesn't mess with that in the meantime since there will be a transition phase, and I won't be implementing host probing in 3.x (we will save it for 4.x with modbus-connection).